### PR TITLE
Match substrings when banning

### DIFF
--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -2,6 +2,10 @@ import {Expansion} from "./Expansions";
 
 export type Civ = string | { leader: string, civ: string }
 
+export function hasLeader(civ: Civ): civ is {leader: string, civ: string} {
+    return !(typeof civ === 'string');
+}
+
 export const Civs : { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
     "civ5-vanilla": [
         "America",

--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -6,6 +6,14 @@ export function hasLeader(civ: Civ): civ is {leader: string, civ: string} {
     return !(typeof civ === 'string');
 }
 
+export function civsEqual(a: Civ, b: Civ) {
+    if (!hasLeader(a) || !hasLeader(b)) {
+        return a === b;
+    }
+    
+    return a.leader === b.leader && a.civ === b.civ;
+}
+
 export const Civs : { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
     "civ5-vanilla": [
         "America",

--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -1,8 +1,8 @@
-import {Expansion} from "./Expansions";
+import {Expansion, Expansions} from "./Expansions";
 
 export type Civ = string | { leader: string, civ: string }
 
-export function hasLeader(civ: Civ): civ is {leader: string, civ: string} {
+export function hasLeader(civ: Civ): civ is { leader: string, civ: string } {
     return !(typeof civ === 'string');
 }
 
@@ -10,7 +10,7 @@ export function civsEqual(a: Civ, b: Civ) {
     if (!hasLeader(a) || !hasLeader(b)) {
         return a === b;
     }
-    
+
     return a.leader === b.leader && a.civ === b.civ;
 }
 
@@ -22,7 +22,24 @@ export function renderCiv(civ: Civ): string {
     return `${civ.leader} - ${civ.civ}`;
 }
 
-export const Civs : { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
+export function renderCivShort(civ: Civ): string {
+    if (!hasLeader(civ)) {
+        return civ;
+    }
+
+    if (leaderHasMultipleCivs(civ.leader)) {
+        return `${civ.leader} (${civ.civ})`;
+    }
+
+    return civ.leader;
+}
+
+function leaderHasMultipleCivs(leader: string) {
+    const flattenedCivs = (Expansions.filter(x => x != "custom") as Exclude<Expansion, "custom">[]).map(x => Civs[x]).flat();
+    return flattenedCivs.filter(civ => hasLeader(civ) && civ.leader === leader).length > 1;
+}
+
+export const Civs: { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
     "civ5-vanilla": [
         "America",
         "Arabia",

--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -1,4 +1,8 @@
-export const Civs = {
+import {Expansion} from "./Expansions";
+
+export type Civ = string | { leader: string, civ: string }
+
+export const Civs : { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
     "civ5-vanilla": [
         "America",
         "Arabia",
@@ -117,100 +121,331 @@ export const Civs = {
     ],
 
     "civ6-vanilla": [
-        'Catherine de Medici',
-        'Cleopatra',
-        'Frederick Barbarossa',
-        'Gandhi',
-        'Gilgamesh',
-        'Gorgo',
-        'Harald Hardrada',
-        'Hojo Tokimune',
-        'Julius Caesar',
-        'Montezuma',
-        'Mvemba a Nzinga',
-        'Pedro II',
-        'Pericles',
-        'Peter',
-        'Philip II',
-        'Qin Shi Huang',
-        'Saladin',
-        'Teddy Roosevelt',
-        'Tomyris',
-        'Trajan',
-        'Victoria'
+        {
+            leader: "Catherine de Medici",
+            civ: "France"
+        },
+        {
+            leader: "Cleopatra",
+            civ: "Egypt"
+        },
+        {
+            leader: "Frederick Barbarossa",
+            civ: "Germany"
+        },
+        {
+            leader: "Gandhi",
+            civ: "India"
+        },
+        {
+            leader: "Gilgamesh",
+            civ: "Sumeria"
+        },
+        {
+            leader: "Gorgo",
+            civ: "Greece"
+        },
+        {
+            leader: "Harald Hardrada",
+            civ: "Norway"
+        },
+        {
+            leader: "Hojo Tokimune",
+            civ: "Japan"
+        },
+        {
+            leader: "Julius Caesar",
+            civ: "Rome"
+        },
+        {
+            leader: "Montezuma",
+            civ: "Aztec"
+        },
+        {
+            leader: "Mvemba a Nzinga",
+            civ: "Kongo"
+        },
+        {
+            leader: "Pedro II",
+            civ: "Brazil"
+        },
+        {
+            leader: "Pericles",
+            civ: "Greece"
+        },
+        {
+            leader: "Peter",
+            civ: "Russia"
+        },
+        {
+            leader: "Philip II",
+            civ: "Spain"
+        },
+        {
+            leader: "Qin Shi Huang",
+            civ: "China"
+        },
+        {
+            leader: "Saladin",
+            civ: "Arabia"
+        },
+        {
+            leader: "Teddy Roosevelt",
+            civ: "America"
+        },
+        {
+            leader: "Tomyris",
+            civ: "Scythia"
+        },
+        {
+            leader: "Trajan",
+            civ: "Rome"
+        },
+        {
+            leader: "Victoria",
+            civ: "England"
+        },
     ],
 
     "civ6-rnf": [
-        'Chandragupta',
-        'Genghis Khan',
-        'Lautaro',
-        'Poundmaker',
-        'Robert the Bruce',
-        'Seondeok',
-        'Shaka',
-        'Tamar',
-        'Wilhelmina'
+        {
+            leader: "Chandragupta",
+            civ: "India"
+        },
+        {
+            leader: "Genghis Khan",
+            civ: "Mongolia"
+        },
+        {
+            leader: "Lautaro",
+            civ: "Mapuche"
+        },
+        {
+            leader: "Poundmaker",
+            civ: "Cree"
+        },
+        {
+            leader: "Robert the Bruce",
+            civ: "Scotland"
+        },
+        {
+            leader: "Seondeok",
+            civ: "Korea"
+        },
+        {
+            leader: "Shaka",
+            civ: "Zulu"
+        },
+        {
+            leader: "Tamar",
+            civ: "Georgia"
+        },
+        {
+            leader: "Wilhelmina",
+            civ: "The Netherlands"
+        }
     ],
 
     "civ6-gs": [
-        'Dido',
-        'Eleanor of Aquitaine (England)',
-        'Eleanor of Aquitaine (France)',
-        'Kristina',
-        'Kupe',
-        'Mansa Musa',
-        'Matthias Corvinus',
-        'Pachacuti',
-        'Suleiman',
-        'Wilfred Laurier'
+        {
+            leader: "Dido",
+            civ: "Carthage"
+        },
+        {
+            leader: "Eleanor of Aquitaine",
+            civ: "England"
+        },
+        {
+            leader: "Eleanor of Aquitaine",
+            civ: "France"
+        },
+        {
+            leader: "Kristina",
+            civ: "Sweden"
+        },
+        {
+            leader: "Kupe",
+            civ: "The Maori"
+        },
+        {
+            leader: "Mansa Musa",
+            civ: "Mali"
+        },
+        {
+            leader: "Matthias Corvinus",
+            civ: "Hungary"
+        },
+        {
+            leader: "Pachacuti",
+            civ: "The Inca"
+        },
+        {
+            leader: "Suleiman",
+            civ: "The Ottomans"
+        },
+        {
+            leader: "Wilfred Laurier",
+            civ: "Canada"
+        }
     ],
 
     "civ6-frontier": [
-        'Ambiorix',
-        'Basil II',
-        'Bà Triệu',
-        'Hammurabi',
-        'João III',
-        'Kublai Khan (China)',
-        'Kublai Khan (Mongolia)',
-        'Lady Six Sky',
-        'Menelik II',
-        'Simón Bolívar'
+        {
+            leader: "Ambiorix",
+            civ: "Gaul"
+        },
+        {
+            leader: "Basil II",
+            civ: "Byzantium"
+        },
+        {
+            leader: "Bà Triệu",
+            civ: "Vietnam"
+        },
+        {
+            leader: "Hammurabi",
+            civ: "Babylon"
+        },
+        {
+            leader: "João III",
+            civ: "Portugal"
+        },
+        {
+            leader: "Kublai Khan",
+            civ: "China"
+        },
+        {
+            leader: "Kublai Khan",
+            civ: "Mongolia"
+        },
+        {
+            leader: "Lady Six Sky",
+            civ: "Maya"
+        },
+        {
+            leader: "Menelik II",
+            civ: "Ethiopia"
+        },
+        {
+            leader: "Simón Bolívar",
+            civ: "Gran Colombia"
+        }
     ],
 
     "civ6-leaderpass": [
-        'Abraham Lincoln',
-        'Cleopatra (Ptolemaic)',
-        'Elizabeth I',
-        'Harald Hardrada (Varangian)',
-        'Ludwig II',
-        'Nader Shah',
-        'Nzinga Mbande',
-        'Qin Shi Huang (Unifier)',
-        'Ramses II',
-        'Saladin (Sultan)',
-        'Sejong',
-        'Suleiman (Muhtesem)',
-        'Sundiata Keita',
-        'Theodora',
-        'Tokugawa',
-        'Victoria (Age of Steam)',
-        'Wu Zetian',
-        'Yongle'
+        {
+            leader: "Abraham Lincoln",
+            civ: "America"
+        },
+        {
+            leader: "Cleopatra (Ptolemaic)",
+            civ: "Egypt"
+        },
+        {
+            leader: "Elizabeth I",
+            civ: "England"
+        },
+        {
+            leader: "Harald Hardrada (Varangian)",
+            civ: "Norway"
+        },
+        {
+            leader: "Ludwig II",
+            civ: "Germany"
+        },
+        {
+            leader: "Nader Shah",
+            civ: "Persia"
+        },
+        {
+            leader: "Nzinga Mbande",
+            civ: "Kongo"
+        },
+        {
+            leader: "Qin Shi Huang (Unifier)",
+            civ: "China"
+        },
+        {
+            leader: "Ramses II",
+            civ: "Egypt"
+        },
+        {
+            leader: "Saladin (Sultan)",
+            civ: "Arabia"
+        },
+        {
+            leader: "Sejong",
+            civ: "Korea"
+        },
+        {
+            leader: "Suleiman (Muhtesem)",
+            civ: "The Ottomans"
+        },
+        {
+            leader: "Sundiata Keita",
+            civ: "Mali"
+        },
+        {
+            leader: "Theodora",
+            civ: "Byzantium"
+        },
+        {
+            leader: "Tokugawa",
+            civ: "Japan"
+        },
+        {
+            leader: "Victoria (Age of Steam)",
+            civ: "England"
+        },
+        {
+            leader: "Wu Zetian",
+            civ: "China"
+        },
+        {
+            leader: "Yongle",
+            civ: "China"
+        }
     ],
 
     "civ6-extra": [
-        'Alexander',
-        'Amanitore',
-        'Cyrus',
-        'Gitarja',
-        'Jadwiga',
-        'Jayavarman VII',
-        'John Curtin'
+        {
+            leader: "Alexander",
+            civ: "Macedon"
+        },
+        {
+            leader: "Amanitore",
+            civ: "Nubia"
+        },
+        {
+            leader: "Cyrus",
+            civ: "Persia"
+        },
+        {
+            leader: "Gitarja",
+            civ: "Indonesia"
+        },
+        {
+            leader: "Jadwiga",
+            civ: "Poland"
+        },
+        {
+            leader: "Jayavarman VII",
+            civ: "Khmer"
+        },
+        {
+            leader: "John Curtin",
+            civ: "Australia"
+        },
     ],
 
     "civ6-personas": [
-        "Catherine de Medici (Magnificence)",
-        "Teddy Roosevelt (Rough Rider)"
+        {
+            leader: "Catherine de Medici (Magnificence)",
+            civ: "France"
+        },
+        {
+            leader: "Teddy Roosevelt (Rough Rider)",
+            civ: "America"
+        }
     ]
 };

--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -14,6 +14,14 @@ export function civsEqual(a: Civ, b: Civ) {
     return a.leader === b.leader && a.civ === b.civ;
 }
 
+export function renderCiv(civ: Civ): string {
+    if (!hasLeader(civ)) {
+        return civ;
+    }
+
+    return `${civ.leader} - ${civ.civ}`;
+}
+
 export const Civs : { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
     "civ5-vanilla": [
         "America",

--- a/src/Civs/Expansions.ts
+++ b/src/Civs/Expansions.ts
@@ -1,8 +1,19 @@
-import {Civs} from "./Civs";
 import {CivGame} from "./CivGames";
 
-export type Expansion = keyof typeof Civs | "custom";
-export const Expansions = Object.keys(Civs).concat("custom") as Expansion[];
+export const Expansions = [
+    "civ5-vanilla", 
+    "lekmod", 
+    "civ6-vanilla", 
+    "civ6-rnf",
+    "civ6-gs",
+    "civ6-frontier",
+    "civ6-leaderpass",
+    "civ6-extra",
+    "civ6-personas",
+    "custom"
+] as const;
+
+export type Expansion = typeof Expansions[number];
 
 const ExpansionMetadata: { [a in Expansion]: { displayName: string; game: CivGame | "All" } } = {
     "civ5-vanilla": {displayName: "Base game + DLC", game: "Civ 5"},

--- a/src/Commands/Ban/Ban.ts
+++ b/src/Commands/Ban/Ban.ts
@@ -1,0 +1,17 @@
+import {UserData} from "../../UserData/UserData";
+import {Civ, civsEqual} from "../../Civs/Civs";
+import {saveUserData} from "../../UserDataStore";
+
+export async function banCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
+    userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.concat(civsToBan);
+    await saveUserData(serverId, userData);
+}
+
+export async function unbanCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
+    userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.filter(civ => !civsToBan.some(x => civsEqual(civ, x)))
+    await saveUserData(serverId, userData);
+}
+
+export function isBanned(civ: Civ, userData: UserData) {
+    return userData.userSettings[userData.game].bannedCivs.some(x => civsEqual(x, civ));
+}

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,6 +1,6 @@
 import {loadUserData, saveUserData} from "../../UserDataStore";
 import {matchCivs} from "./CivExists";
-import {Civ, civsEqual, hasLeader} from "../../Civs/Civs";
+import {Civ, civsEqual, renderCiv} from "../../Civs/Civs";
 import {ChatInputCommandInteraction} from "discord.js";
 import {UserData} from "../../UserData/UserData";
 import {MAX_OPTIONS, multipleChoice} from "./MultipleChoice";
@@ -57,12 +57,4 @@ function banMessage(bannedCivs: Civ[]) {
     }
 
     return `The following civs have been banned: \`\`\`${bannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will no longer appear in your drafts.`;
-}
-
-function renderCiv(civ: Civ): string {
-    if (!hasLeader(civ)) {
-        return civ;
-    }
-
-    return `${civ.leader} - ${civ.civ}`;
 }

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -52,5 +52,5 @@ function banMessage(bannedCivs: Civ[]) {
         return `\`${renderCiv(bannedCivs[0])}\` has been banned. It will no longer appear in your drafts.`;
     }
 
-    return `The following civs have been banned: \`\`\`${bannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will no longer appear in your drafts.`;
+    return `The following civs have been banned: \`\`\`\n${bannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will no longer appear in your drafts.`;
 }

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,6 +1,80 @@
-import { loadUserData, saveUserData } from "../../UserDataStore";
+import {loadUserData, saveUserData} from "../../UserDataStore";
 import {matchCivs} from "./CivExists";
 import {Civ, hasLeader} from "../../Civs/Civs";
+import {ChatInputCommandInteraction} from "discord.js";
+import {UserData} from "../../UserData/UserData";
+import {logInfo} from "../../Log";
+
+export async function handleBan(interaction: ChatInputCommandInteraction) {
+    const serverId = interaction.guildId!;
+
+    const civToBan = interaction.options.getString("civ")!;
+    const userData = await loadUserData(serverId);
+
+    const matchedCivs = matchCivs(civToBan, userData.game);
+
+    if (matchedCivs.length === 0) {
+        await interaction.reply(`No civ called ${civToBan} exists in ${userData.game}.`);
+        return;
+    }
+    else if (matchedCivs.length > 5) {
+        await interaction.reply(`"${civToBan}" matches ${matchedCivs.length} civs. Please me more specific.`);
+    }
+    else if (matchedCivs.length > 1) {
+        const message = await interaction.reply({
+            content: renderCivSelectionMessage(civToBan, matchedCivs),
+            fetchReply: true
+        });
+
+        await message.react(allEmoji)
+        for (const emoji of numberEmojis.slice(0, matchedCivs.length)) {
+            await message.react(emoji);
+        }
+
+        logInfo("Matched multiple civs. Waiting for user reaction...");
+        const userReactions = await message.awaitReactions({
+            filter: (reaction, user) => numberEmojis.concat(allEmoji).includes(reaction.emoji.name ?? "") && user.id === interaction.user.id,
+            time: 10_000,
+            max: 1
+        });
+
+        const reaction = userReactions.first();
+        if (reaction === undefined) {
+            await message.edit(`Request to ban civ timed out.`);
+            return;
+        }
+        if (reaction.emoji.name === allEmoji) {
+            await banCivs(serverId, userData, matchedCivs);
+            await message.edit(`Banned ${matchedCivs.length} civs.`);
+            return;
+        } else if (numberEmojis.includes(reaction.emoji.name!)) {
+            const chosenCiv = matchedCivs[numberEmojis.indexOf(reaction.emoji.name!)];
+            await banCivs(serverId, userData, [chosenCiv]);
+            await message.edit(banMessage(chosenCiv));
+            return;
+        }
+    }
+
+    await banCivs(serverId, userData, matchedCivs);
+    const message = banMessage(matchedCivs[0]);
+
+    await interaction.reply(message);
+}
+
+async function banCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
+    userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.concat(civsToBan);
+    await saveUserData(serverId, userData);
+}
+
+function banMessage(bannedCiv: Civ) {
+    return `\`${renderCiv(bannedCiv)}\` has been banned. It will no longer appear in your drafts.`
+}
+
+function renderCivSelectionMessage(civToBan: Civ, matchedCivs: Civ[]) {
+    return `"${civToBan}" matches ${matchedCivs.length} civs. Please click one of the reacts to select which one to ban:
+${matchedCivs.map((x, i) => `${numberEmojis[i]}: ${renderCiv(x)}`).join("\n")}
+${allEmoji}: All`
+}
 
 function renderCiv(civ: Civ): string {
     if (!hasLeader(civ)) {
@@ -10,22 +84,5 @@ function renderCiv(civ: Civ): string {
     return `${civ.leader} - ${civ.civ}`;
 }
 
-export async function banCommand(tenantId: string, civToBan: string) {
-    const userData = await loadUserData(tenantId);
-    
-    const matchedCivs = matchCivs(civToBan, userData.game);
-    
-    if (matchedCivs.length === 0) {
-        return `No civ called ${civToBan} exists in ${userData.game}.`;
-    }
-    else if (matchedCivs.length > 1) {
-        return `
-"${civToBan}" matches ${matchedCivs.length} civs:
-\`\`\`${matchedCivs.map(renderCiv).join("\n")}\`\`\`
-Please be more specific.`
-    }
-    
-    userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.concat(civToBan);
-    await saveUserData(tenantId, userData);
-    return `\`${renderCiv(matchedCivs[0])}\` has been banned. It will no longer appear in your drafts.`;
-}
+const numberEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣']
+const allEmoji = '💥'

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -34,7 +34,7 @@ export async function handleBan(interaction: ChatInputCommandInteraction) {
         logInfo("Matched multiple civs. Waiting for user reaction...");
         const userReactions = await message.awaitReactions({
             filter: (reaction, user) => numberEmojis.concat(allEmoji).includes(reaction.emoji.name ?? "") && user.id === interaction.user.id,
-            time: 10_000,
+            time: 60_000,
             max: 1
         });
 

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -17,7 +17,7 @@ export async function handleBan(interaction: ChatInputCommandInteraction) {
         await interaction.reply(`No civ called ${civToBan} exists in ${userData.game}.`);
         return;
     }
-    else if (matchedCivs.length > 5) {
+    else if (matchedCivs.length > numberEmojis.length) {
         await interaction.reply(`"${civToBan}" matches ${matchedCivs.length} civs. Please me more specific.`);
     }
     else if (matchedCivs.length > 1) {

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,7 +1,7 @@
 import {loadUserData, saveUserData} from "../../UserDataStore";
 import {matchCivs} from "./CivExists";
 import {Civ, hasLeader} from "../../Civs/Civs";
-import {ChatInputCommandInteraction} from "discord.js";
+import {ChatInputCommandInteraction, Message} from "discord.js";
 import {UserData} from "../../UserData/UserData";
 import {logInfo} from "../../Log";
 
@@ -16,39 +16,29 @@ export async function handleBan(interaction: ChatInputCommandInteraction) {
     if (matchedCivs.length === 0) {
         await interaction.reply(`No civ called ${civToBan} exists in ${userData.game}.`);
         return;
-    }
-    else if (matchedCivs.length > numberEmojis.length) {
+    } else if (matchedCivs.length > numberEmojis.length) {
         await interaction.reply(`"${civToBan}" matches ${matchedCivs.length} civs. Please me more specific.`);
-    }
-    else if (matchedCivs.length > 1) {
+        return;
+    } else if (matchedCivs.length > 1) {
         const message = await interaction.reply({
             content: renderCivSelectionMessage(civToBan, matchedCivs),
             fetchReply: true
         });
 
-        await message.react(allEmoji)
-        for (const emoji of numberEmojis.slice(0, matchedCivs.length)) {
-            await message.react(emoji);
-        }
-
         logInfo("Matched multiple civs. Waiting for user reaction...");
-        const userReactions = await message.awaitReactions({
-            filter: (reaction, user) => numberEmojis.concat(allEmoji).includes(reaction.emoji.name ?? "") && user.id === interaction.user.id,
-            time: 60_000,
-            max: 1
-        });
+        await addReactions(message, matchedCivs.length);
+        const reactionEmoji = await waitForUserReaction(message, interaction.user.id);
 
-        const reaction = userReactions.first();
-        if (reaction === undefined) {
+        if (reactionEmoji === undefined) {
             await message.edit(`Request to ban civ timed out.`);
             return;
         }
-        if (reaction.emoji.name === allEmoji) {
+        if (reactionEmoji === allEmoji) {
             await banCivs(serverId, userData, matchedCivs);
             await message.edit(banMessage(matchedCivs));
             return;
-        } else if (numberEmojis.includes(reaction.emoji.name!)) {
-            const chosenCiv = matchedCivs[numberEmojis.indexOf(reaction.emoji.name!)];
+        } else if (numberEmojis.includes(reactionEmoji)) {
+            const chosenCiv = matchedCivs[numberEmojis.indexOf(reactionEmoji)];
             await banCivs(serverId, userData, [chosenCiv]);
             await message.edit(banMessage([chosenCiv]));
             return;
@@ -56,9 +46,7 @@ export async function handleBan(interaction: ChatInputCommandInteraction) {
     }
 
     await banCivs(serverId, userData, matchedCivs);
-    const message = banMessage(matchedCivs);
-
-    await interaction.reply(message);
+    await interaction.reply(banMessage(matchedCivs));
 }
 
 async function banCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
@@ -70,8 +58,25 @@ function banMessage(bannedCivs: Civ[]) {
     if (bannedCivs.length == 1) {
         return `\`${renderCiv(bannedCivs[0])}\` has been banned. It will no longer appear in your drafts.`;
     }
-    
+
     return `${bannedCivs.map(x => `\`${x}\``).join(", ")} have been banned. They will no longer appear in your drafts.`;
+}
+
+async function addReactions(message: Message, numChoices: number) {
+    await message.react(allEmoji)
+    for (const emoji of numberEmojis.slice(0, numChoices)) {
+        await message.react(emoji);
+    }
+}
+
+async function waitForUserReaction(message: Message, userId: string) {
+    const userReactions = await message.awaitReactions({
+        filter: (reaction, user) => numberEmojis.concat(allEmoji).includes(reaction.emoji.name ?? "") && user.id === userId,
+        time: 60_000,
+        max: 1
+    });
+
+    return userReactions.first()?.emoji?.name ?? undefined;
 }
 
 function renderCivSelectionMessage(civToBan: Civ, matchedCivs: Civ[]) {

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,14 +1,31 @@
 import { loadUserData, saveUserData } from "../../UserDataStore";
-import { civExists } from "./CivExists";
+import {matchCivs} from "./CivExists";
+import {Civ, hasLeader} from "../../Civs/Civs";
+
+function renderCiv(civ: Civ): string {
+    if (!hasLeader(civ)) {
+        return civ;
+    }
+
+    return `${civ.leader} - ${civ.civ}`;
+}
 
 export async function banCommand(tenantId: string, civToBan: string) {
     const userData = await loadUserData(tenantId);
     
-    if (!civExists(civToBan, userData.game)) {
+    const matchedCivs = matchCivs(civToBan, userData.game);
+    
+    if (matchedCivs.length === 0) {
         return `No civ called ${civToBan} exists in ${userData.game}.`;
+    }
+    else if (matchedCivs.length > 1) {
+        return `
+"${civToBan}" matches ${matchedCivs.length} civs:
+\`\`\`${matchedCivs.map(renderCiv).join("\n")}\`\`\`
+Please be more specific.`
     }
     
     userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.concat(civToBan);
     await saveUserData(tenantId, userData);
-    return `${civToBan} has been banned. It will no longer appear in your drafts.`;
+    return `\`${renderCiv(matchedCivs[0])}\` has been banned. It will no longer appear in your drafts.`;
 }

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,9 +1,9 @@
 import {loadUserData, saveUserData} from "../../UserDataStore";
 import {matchCivs} from "./CivExists";
 import {Civ, civsEqual, hasLeader} from "../../Civs/Civs";
-import {ChatInputCommandInteraction, Message} from "discord.js";
+import {ChatInputCommandInteraction} from "discord.js";
 import {UserData} from "../../UserData/UserData";
-import {logInfo} from "../../Log";
+import {MAX_OPTIONS, multipleChoice} from "./MultipleChoice";
 
 export async function handleBan(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -14,42 +14,27 @@ export async function handleBan(interaction: ChatInputCommandInteraction) {
     const allMatchedCivs = matchCivs(searchString, userData.game);
     const alreadyBannedCivs = allMatchedCivs.filter(x => isBanned(x, userData))
     const availableMatchedCivs = allMatchedCivs.filter(x => !isBanned(x, userData))
-    
+
     if (availableMatchedCivs.length === 0) {
         if (alreadyBannedCivs.length == 1) {
             await interaction.reply(`\`${renderCiv(alreadyBannedCivs[0])}\` is already banned.`);
-        }
-        else if (alreadyBannedCivs.length > 1) {
+        } else if (alreadyBannedCivs.length > 1) {
             await interaction.reply(`"${searchString}" matches ${alreadyBannedCivs.length} civs, but they are all already banned.`);
         }
         await interaction.reply(`No civ called "${searchString}" exists in ${userData.game}.`);
         return;
-    } else if (availableMatchedCivs.length > numberEmojis.length) {
+    } else if (availableMatchedCivs.length > MAX_OPTIONS) {
         await interaction.reply(`"${searchString}" matches ${availableMatchedCivs.length} civs that aren't already banned. Please me more specific.`);
         return;
     } else if (availableMatchedCivs.length > 1) {
-        const message = await interaction.reply({
-            content: renderCivSelectionMessage(searchString, availableMatchedCivs),
-            fetchReply: true
+        const chosenCivs = await multipleChoice(interaction, availableMatchedCivs.map(renderCiv), {
+            question: `"${searchString}" matches ${availableMatchedCivs.length} civs that aren't already banned. Please click one of the reacts to select which one to ban:`,
+            selected: banMessage,
+            timeout: "Request to ban civ timed out."
         });
 
-        logInfo("Matched multiple civs. Waiting for user reaction...");
-        await addReactions(message, availableMatchedCivs.length);
-        const reactionEmoji = await waitForUserReaction(message, interaction.user.id);
-
-        if (reactionEmoji === undefined) {
-            await message.edit(`Request to ban civ timed out.`);
-            return;
-        }
-        if (reactionEmoji === allEmoji) {
-            await banCivs(serverId, userData, availableMatchedCivs);
-            await message.edit(banMessage(availableMatchedCivs));
-            return;
-        } else if (numberEmojis.includes(reactionEmoji)) {
-            const chosenCiv = availableMatchedCivs[numberEmojis.indexOf(reactionEmoji)];
-            await banCivs(serverId, userData, [chosenCiv]);
-            await message.edit(banMessage([chosenCiv]));
-            return;
+        if (chosenCivs) {
+            await banCivs(serverId, userData, chosenCivs)
         }
     }
 
@@ -74,29 +59,6 @@ function banMessage(bannedCivs: Civ[]) {
     return `The following civs have been banned: \`\`\`${bannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will no longer appear in your drafts.`;
 }
 
-async function addReactions(message: Message, numChoices: number) {
-    await message.react(allEmoji)
-    for (const emoji of numberEmojis.slice(0, numChoices)) {
-        await message.react(emoji);
-    }
-}
-
-async function waitForUserReaction(message: Message, userId: string) {
-    const userReactions = await message.awaitReactions({
-        filter: (reaction, user) => numberEmojis.concat(allEmoji).includes(reaction.emoji.name ?? "") && user.id === userId,
-        time: 60_000,
-        max: 1
-    });
-
-    return userReactions.first()?.emoji?.name ?? undefined;
-}
-
-function renderCivSelectionMessage(civToBan: Civ, matchedCivs: Civ[]) {
-    return `"${civToBan}" matches ${matchedCivs.length} civs that aren't already banned. Please click one of the reacts to select which one to ban:
-${matchedCivs.map((x, i) => `${numberEmojis[i]}: ${renderCiv(x)}`).join("\n")}
-${allEmoji}: All`
-}
-
 function renderCiv(civ: Civ): string {
     if (!hasLeader(civ)) {
         return civ;
@@ -104,6 +66,3 @@ function renderCiv(civ: Civ): string {
 
     return `${civ.leader} - ${civ.civ}`;
 }
-
-const numberEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣']
-const allEmoji = '💥'

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -45,18 +45,18 @@ export async function handleBan(interaction: ChatInputCommandInteraction) {
         }
         if (reaction.emoji.name === allEmoji) {
             await banCivs(serverId, userData, matchedCivs);
-            await message.edit(`Banned ${matchedCivs.length} civs.`);
+            await message.edit(banMessage(matchedCivs));
             return;
         } else if (numberEmojis.includes(reaction.emoji.name!)) {
             const chosenCiv = matchedCivs[numberEmojis.indexOf(reaction.emoji.name!)];
             await banCivs(serverId, userData, [chosenCiv]);
-            await message.edit(banMessage(chosenCiv));
+            await message.edit(banMessage([chosenCiv]));
             return;
         }
     }
 
     await banCivs(serverId, userData, matchedCivs);
-    const message = banMessage(matchedCivs[0]);
+    const message = banMessage(matchedCivs);
 
     await interaction.reply(message);
 }
@@ -66,8 +66,12 @@ async function banCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
     await saveUserData(serverId, userData);
 }
 
-function banMessage(bannedCiv: Civ) {
-    return `\`${renderCiv(bannedCiv)}\` has been banned. It will no longer appear in your drafts.`
+function banMessage(bannedCivs: Civ[]) {
+    if (bannedCivs.length == 1) {
+        return `\`${renderCiv(bannedCivs[0])}\` has been banned. It will no longer appear in your drafts.`;
+    }
+    
+    return `${bannedCivs.map(x => `\`${x}\``).join(", ")} have been banned. They will no longer appear in your drafts.`;
 }
 
 function renderCivSelectionMessage(civToBan: Civ, matchedCivs: Civ[]) {

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -59,7 +59,7 @@ function banMessage(bannedCivs: Civ[]) {
         return `\`${renderCiv(bannedCivs[0])}\` has been banned. It will no longer appear in your drafts.`;
     }
 
-    return `${bannedCivs.map(x => `\`${x}\``).join(", ")} have been banned. They will no longer appear in your drafts.`;
+    return `The following civs have been banned: \`\`\`${bannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will no longer appear in your drafts.`;
 }
 
 async function addReactions(message: Message, numChoices: number) {

--- a/src/Commands/Ban/CivExists.ts
+++ b/src/Commands/Ban/CivExists.ts
@@ -1,6 +1,25 @@
 import {expansionsInGame} from "../../Civs/Expansions";
-import { Civs } from "../../Civs/Civs";
+import {Civ, Civs, hasLeader} from "../../Civs/Civs";
 import {CivGame} from "../../Civs/CivGames";
+
+export function matchCivs(civString: string, civGame: CivGame): Civ[] {
+    const allCivsInGame = expansionsInGame(civGame).reduce((acc, value) => acc.concat(Civs[value]), new Array<Civ>()).filter(Boolean);
+    
+    return allCivsInGame.filter(civ => {
+        if (hasLeader(civ)) {
+            if (civ.civ.includes(civString) || civ.leader.includes(civString)) {
+                return true;
+            } 
+        }
+        else {
+            if (civ.includes(civString)) {
+                return true;
+            }
+        }
+        
+        return false;
+    });
+}
 
 export function civExists(civToBan: string, civGame: CivGame) {
     const allCivsInGame = expansionsInGame(civGame).reduce((acc, value) => acc.concat(Civs[value]), new Array<string>());

--- a/src/Commands/Ban/MatchCivs.ts
+++ b/src/Commands/Ban/MatchCivs.ts
@@ -6,13 +6,14 @@ export function matchCivs(civString: string, civGame: CivGame): Civ[] {
     const allCivsInGame = expansionsInGame(civGame).reduce((acc, value) => acc.concat(Civs[value]), new Array<Civ>()).filter(Boolean);
     
     return allCivsInGame.filter(civ => {
+        const lowercaseCivString = civString.toLowerCase();
         if (hasLeader(civ)) {
-            if (civ.civ.includes(civString) || civ.leader.includes(civString)) {
+            if (civ.civ.toLowerCase().includes(lowercaseCivString) || civ.leader.toLowerCase().includes(lowercaseCivString)) {
                 return true;
             } 
         }
         else {
-            if (civ.includes(civString)) {
+            if (civ.toLowerCase().includes(lowercaseCivString)) {
                 return true;
             }
         }

--- a/src/Commands/Ban/MatchCivs.ts
+++ b/src/Commands/Ban/MatchCivs.ts
@@ -20,8 +20,3 @@ export function matchCivs(civString: string, civGame: CivGame): Civ[] {
         return false;
     });
 }
-
-export function civExists(civToBan: string, civGame: CivGame) {
-    const allCivsInGame = expansionsInGame(civGame).reduce((acc, value) => acc.concat(Civs[value]), new Array<string>());
-    return allCivsInGame.includes(civToBan);
-}

--- a/src/Commands/Ban/MultipleChoice.ts
+++ b/src/Commands/Ban/MultipleChoice.ts
@@ -1,0 +1,51 @@
+import {CommandInteraction, Message} from "discord.js";
+
+const numberEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣']
+const allEmoji = '💥'
+export const MAX_OPTIONS = numberEmojis.length;
+
+export async function multipleChoice(interaction: CommandInteraction, options: string[], messages: {question: string, timeout: string, selected: (selectedOptions: string[]) => string}): Promise<string[] | undefined>{
+    const reply = await interaction.reply({
+        content: `${messages.question}
+${renderOptionsMessage(options)}`,
+        fetchReply: true
+    });
+    
+    await addReactions(reply, options.length);
+    const reactionEmoji = await waitForUserReaction(reply, interaction.user.id);
+
+    if (reactionEmoji === undefined) {
+        await reply.edit(messages.timeout);
+        return undefined;
+    }
+    if (reactionEmoji === allEmoji) {
+        await reply.edit(messages.selected(options));
+        return options;
+    } else if (numberEmojis.includes(reactionEmoji)) {
+        const selectedOption = options[numberEmojis.indexOf(reactionEmoji)];
+        await reply.edit(messages.selected([selectedOption]));
+        return [selectedOption];
+    }
+}
+
+async function addReactions(message: Message, numChoices: number) {
+    await message.react(allEmoji)
+    for (const emoji of numberEmojis.slice(0, numChoices)) {
+        await message.react(emoji);
+    }
+}
+
+async function waitForUserReaction(message: Message, userId: string) {
+    const userReactions = await message.awaitReactions({
+        filter: (reaction, user) => numberEmojis.concat(allEmoji).includes(reaction.emoji.name ?? "") && user.id === userId,
+        time: 60_000,
+        max: 1
+    });
+
+    return userReactions.first()?.emoji?.name ?? undefined;
+}
+
+function renderOptionsMessage(options: string[]) {
+    return `${options.map((x, i) => `${numberEmojis[i]}: ${x}`).join("\n")}
+${allEmoji}: All`
+}

--- a/src/Commands/Ban/MultipleChoice.ts
+++ b/src/Commands/Ban/MultipleChoice.ts
@@ -4,13 +4,22 @@ const numberEmojis = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣']
 const allEmoji = '💥'
 export const MAX_OPTIONS = numberEmojis.length;
 
-export async function multipleChoice(interaction: CommandInteraction, options: string[], messages: {question: string, timeout: string, selected: (selectedOptions: string[]) => string}): Promise<string[] | undefined>{
+export async function multipleChoice<TOption>(
+    interaction: CommandInteraction,
+    options: TOption[],
+    renderOption: (option: TOption) => string,
+    messages: {
+        question: string,
+        timeout: string,
+        selected: (selectedOptions: TOption[]) => string
+    }
+): Promise<TOption[] | undefined> {
     const reply = await interaction.reply({
         content: `${messages.question}
-${renderOptionsMessage(options)}`,
+${renderOptionsMessage(options.map(renderOption))}`,
         fetchReply: true
     });
-    
+
     await addReactions(reply, options.length);
     const reactionEmoji = await waitForUserReaction(reply, interaction.user.id);
 

--- a/src/Commands/Ban/UnbanCommand.ts
+++ b/src/Commands/Ban/UnbanCommand.ts
@@ -54,5 +54,5 @@ function unbanMessage(unbannedCivs: Civ[]) {
         return `\`${renderCiv(unbannedCivs[0])}\` has been unbanned. It will once again appear in your drafts.`;
     }
 
-    return `The following civs have been unbanned: \`\`\`${unbannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will once again appear in your drafts.`;
+    return `The following civs have been unbanned: \`\`\`\n${unbannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will once again appear in your drafts.`;
 }

--- a/src/Commands/Ban/UnbanCommand.ts
+++ b/src/Commands/Ban/UnbanCommand.ts
@@ -1,19 +1,58 @@
-import { loadUserData, saveUserData } from "../../UserDataStore";
-import { civExists } from "./CivExists";
+import {loadUserData} from "../../UserDataStore";
+import {matchCivs} from "./MatchCivs";
+import {ChatInputCommandInteraction} from "discord.js";
+import {Civ, renderCiv} from "../../Civs/Civs";
+import {MAX_OPTIONS, multipleChoice} from "./MultipleChoice";
+import {isBanned, unbanCivs} from "./Ban";
 
-export async function unbanCommand(tenantId: string, civToUnban: string) {
-    const userData = await loadUserData(tenantId);
+export async function handleUnban(interaction: ChatInputCommandInteraction) {
+    const serverId = interaction.guildId!;
 
-    if (!civExists(civToUnban, userData.game)) {
-        return `No civ called ${civToUnban} exists in ${userData.game}.`;
+    const searchString = interaction.options.getString("civ")!;
+    const userData = await loadUserData(serverId);
+
+    const allMatchedCivs = matchCivs(searchString, userData.game);
+    const matchedBannedCivs = allMatchedCivs.filter(x => isBanned(x, userData))
+    const alreadyUnbannedCivs = allMatchedCivs.filter(x => !isBanned(x, userData))
+
+    if (matchedBannedCivs.length === 0) {
+        if (alreadyUnbannedCivs.length == 1) {
+            await interaction.reply(`\`${renderCiv(matchedBannedCivs[0])}\` is not banned, so it cannot be unbanned.`);
+            return;
+        } else if (alreadyUnbannedCivs.length > 1) {
+            await interaction.reply(`"${searchString}" matches ${alreadyUnbannedCivs.length} civs, but none of them are banned.`);
+            return;
+        }
+        await interaction.reply(`No civ called "${searchString}" exists in ${userData.game}.`);
+        return;
+    } else if (matchedBannedCivs.length > MAX_OPTIONS) {
+        await interaction.reply(`"${searchString}" matches ${matchedBannedCivs.length} banned civs. Please me more specific.`);
+        return;
+    } else if (matchedBannedCivs.length > 1) {
+        const chosenCivs = await multipleChoice(
+            interaction,
+            matchedBannedCivs,
+            renderCiv,
+            {
+                question: `"${searchString}" matches ${matchedBannedCivs.length} banned civs. Please click one of the reacts to select which one to unban:`,
+                selected: unbanMessage,
+                timeout: "Request to unban civ timed out."
+            });
+
+        if (chosenCivs) {
+            await unbanCivs(serverId, userData, chosenCivs)
+            return;
+        }
     }
 
-    if (!userData.userSettings[userData.game].bannedCivs.includes(civToUnban)) {
-        return `${civToUnban} is not banned, so it cannot be unbanned.`;
-    }
-    const toRemoveIndex = userData.userSettings[userData.game].bannedCivs.indexOf(civToUnban);
-    userData.userSettings[userData.game].bannedCivs.splice(toRemoveIndex, 1);
+    await unbanCivs(serverId, userData, matchedBannedCivs);
+    await interaction.reply(unbanMessage(matchedBannedCivs));
+}
 
-    await saveUserData(tenantId, userData);
-    return `${civToUnban} has been unbanned. It will appear in your drafts once again.`;
+function unbanMessage(unbannedCivs: Civ[]) {
+    if (unbannedCivs.length == 1) {
+        return `\`${renderCiv(unbannedCivs[0])}\` has been unbanned. It will once again appear in your drafts.`;
+    }
+
+    return `The following civs have been unbanned: \`\`\`${unbannedCivs.map(x => renderCiv(x)).join("\n")}\`\`\` They will once again appear in your drafts.`;
 }

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -1,6 +1,6 @@
 import {displayName} from "../../Civs/Expansions";
 import {UserData} from "../../UserData/UserData";
-import {Civ} from "../../Civs/Civs";
+import {Civ, renderCiv} from "../../Civs/Civs";
 
 export function showConfigCommand(userData: UserData): string {
     const activeSettings = userData.userSettings[userData.game];
@@ -29,12 +29,4 @@ function customCivsLine(customCivs: string[]) {
 
 function bannedCivsLine(bannedCivs: Civ[]) {
     return `Banned civs:\`\`\`\n${bannedCivs.sort().map(renderCiv).join("\n")}\`\`\``;
-}
-
-function renderCiv(civ: Civ) {
-    if (typeof civ === "string") {
-        return civ;
-    }
-    
-    return civ.leader;
 }

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -1,5 +1,6 @@
 import {displayName} from "../../Civs/Expansions";
 import {UserData} from "../../UserData/UserData";
+import {Civ} from "../../Civs/Civs";
 
 export function showConfigCommand(userData: UserData): string {
     const activeSettings = userData.userSettings[userData.game];
@@ -26,6 +27,14 @@ function customCivsLine(customCivs: string[]) {
     }
 }
 
-function bannedCivsLine(bannedCivs: string[]) {
-    return `Banned civs:\`\`\`\n${bannedCivs.sort().join("\n")}\`\`\``;
+function bannedCivsLine(bannedCivs: Civ[]) {
+    return `Banned civs:\`\`\`\n${bannedCivs.sort().map(renderCiv).join("\n")}\`\`\``;
+}
+
+function renderCiv(civ: Civ) {
+    if (typeof civ === "string") {
+        return civ;
+    }
+    
+    return civ.leader;
 }

--- a/src/Commands/Draft/Draft.ts
+++ b/src/Commands/Draft/Draft.ts
@@ -1,8 +1,9 @@
 import { Draft, DraftError } from "./DraftTypes";
 import * as shuffle from "shuffle-array";
 import { Result } from "../../Functional/Result";
+import {Civ} from "../../Civs/Civs";
 
-function assignCivs(players: string[], civsPerPlayer: number, civs: string[]): Draft {
+function assignCivs(players: string[], civsPerPlayer: number, civs: Civ[]): Draft {
     shuffle(civs);
 
     return players.map((player, index) => {
@@ -10,7 +11,7 @@ function assignCivs(players: string[], civsPerPlayer: number, civs: string[]): D
     });
 }
 
-export function draft(players: string[], civsPerPlayer: number, civs: string[]): Result<Draft, DraftError> {
+export function draft(players: string[], civsPerPlayer: number, civs: Civ[]): Result<Draft, DraftError> {
     if (players.length == 0) {
         return { isError: true, error: "no-players" };
     }

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -2,14 +2,14 @@
 import { Draft, DraftEntry, DraftError } from "./DraftTypes";
 import {Expansion, displayName} from "../../Civs/Expansions";
 import { Result } from "../../Functional/Result";
-import {renderCiv} from "../../Civs/Civs";
+import {renderCivShort} from "../../Civs/Civs";
 
 function getPlayerDraftString(draftEntry: DraftEntry): string {
     let response = `${draftEntry.player} `.padEnd(20, " ");
     for (let j = 0; j < draftEntry.civs.length - 1; j++) {
-        response += `${renderCiv(draftEntry.civs[j])} / `;
+        response += `${renderCivShort(draftEntry.civs[j])} / `;
     }
-    response += `${renderCiv(draftEntry.civs[draftEntry.civs.length - 1])}`;
+    response += `${renderCivShort(draftEntry.civs[draftEntry.civs.length - 1])}`;
     return response;
 }
 

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -2,15 +2,7 @@
 import { Draft, DraftEntry, DraftError } from "./DraftTypes";
 import {Expansion, displayName} from "../../Civs/Expansions";
 import { Result } from "../../Functional/Result";
-import {Civ} from "../../Civs/Civs";
-
-function renderCiv(civ: Civ): string {
-    if (typeof civ === "string") {
-        return civ;
-    }
-    
-    return `${civ.leader} (${civ.civ})`;
-}
+import {renderCiv} from "../../Civs/Civs";
 
 function getPlayerDraftString(draftEntry: DraftEntry): string {
     let response = `${draftEntry.player} `.padEnd(20, " ");

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -2,13 +2,22 @@
 import { Draft, DraftEntry, DraftError } from "./DraftTypes";
 import {Expansion, displayName} from "../../Civs/Expansions";
 import { Result } from "../../Functional/Result";
+import {Civ} from "../../Civs/Civs";
+
+function renderCiv(civ: Civ): string {
+    if (typeof civ === "string") {
+        return civ;
+    }
+    
+    return `${civ.leader} (${civ.civ})`;
+}
 
 function getPlayerDraftString(draftEntry: DraftEntry): string {
     let response = `${draftEntry.player} `.padEnd(20, " ");
     for (let j = 0; j < draftEntry.civs.length - 1; j++) {
-        response += `${draftEntry.civs[j]} / `;
+        response += `${renderCiv(draftEntry.civs[j])} / `;
     }
-    response += `${draftEntry.civs[draftEntry.civs.length - 1]}`;
+    response += `${renderCiv(draftEntry.civs[draftEntry.civs.length - 1])}`;
     return response;
 }
 

--- a/src/Commands/Draft/DraftTypes.ts
+++ b/src/Commands/Draft/DraftTypes.ts
@@ -1,8 +1,10 @@
-﻿export type Draft = DraftEntry[];
+﻿import {Civ} from "../../Civs/Civs";
+
+export type Draft = DraftEntry[];
 
 export type DraftEntry = {
     player: string;
-    civs: string[];
+    civs: Civ[];
 };
 
 export type DraftError = "no-players" | "not-enough-civs";

--- a/src/Commands/Draft/SelectCivs.ts
+++ b/src/Commands/Draft/SelectCivs.ts
@@ -1,7 +1,7 @@
 ﻿import { Expansion } from "../../Civs/Expansions";
-import { Civs } from "../../Civs/Civs";
+import {Civ, Civs} from "../../Civs/Civs";
 
-export function selectCivs(expansions: Expansion[], customCivs: string[], bannedCivs: string[]): string[] {
+export function selectCivs(expansions: Expansion[], customCivs: string[], bannedCivs: Civ[]): Civ[] {
     return Array.from(new Set(expansions))
         .map((expansion) => {
             if (expansion === "custom") {
@@ -9,6 +9,6 @@ export function selectCivs(expansions: Expansion[], customCivs: string[], banned
             }
             return Civs[expansion];
         })
-        .reduce((prev: string[], current: string[]) => current.concat(prev), [])
+        .reduce((prev: Civ[], current: Civ[]) => current.concat(prev), [])
         .filter(x => !bannedCivs.includes(x));
 }

--- a/src/Discord/SlashCommands/HandleSlashCommand.ts
+++ b/src/Discord/SlashCommands/HandleSlashCommand.ts
@@ -8,7 +8,7 @@ import {enableExpansionCommand} from "../../Commands/Expansions/EnableExpansionC
 import {disableExpansionCommand} from "../../Commands/Expansions/DisableExpansionCommand";
 import {loadUserData} from "../../UserDataStore";
 import {handleBan} from "../../Commands/Ban/BanCommand";
-import {unbanCommand} from "../../Commands/Ban/UnbanCommand";
+import {handleUnban} from "../../Commands/Ban/UnbanCommand";
 import {logError, logInfo} from "../../Log";
 import {switchGameCommand} from "../../Commands/SwitchGame/SwitchGameCommand";
 import {updateSlashCommandsForServer} from "./UpdateSlashCommands";
@@ -178,15 +178,6 @@ async function handleCustomCivs(interaction: ChatInputCommandInteraction) {
     const userData = await loadUserData(serverId);
 
     await interaction.showModal(customCivsModal(userData.userSettings[userData.game].customCivs));
-}
-
-async function handleUnban(interaction: ChatInputCommandInteraction) {
-    const serverId = interaction.guildId!;
-
-    const civToUnban = interaction.options.getString("civ")!;
-    const message = await unbanCommand(serverId, civToUnban);
-
-    await interaction.reply(message);
 }
 
 async function handleSwitchGame(interaction: ChatInputCommandInteraction) {

--- a/src/Discord/SlashCommands/HandleSlashCommand.ts
+++ b/src/Discord/SlashCommands/HandleSlashCommand.ts
@@ -7,7 +7,7 @@ import {showConfigCommand} from "../../Commands/Config/ShowConfigCommand";
 import {enableExpansionCommand} from "../../Commands/Expansions/EnableExpansionCommand";
 import {disableExpansionCommand} from "../../Commands/Expansions/DisableExpansionCommand";
 import {loadUserData} from "../../UserDataStore";
-import {banCommand} from "../../Commands/Ban/BanCommand";
+import {handleBan} from "../../Commands/Ban/BanCommand";
 import {unbanCommand} from "../../Commands/Ban/UnbanCommand";
 import {logError, logInfo} from "../../Log";
 import {switchGameCommand} from "../../Commands/SwitchGame/SwitchGameCommand";
@@ -178,15 +178,6 @@ async function handleCustomCivs(interaction: ChatInputCommandInteraction) {
     const userData = await loadUserData(serverId);
 
     await interaction.showModal(customCivsModal(userData.userSettings[userData.game].customCivs));
-}
-
-async function handleBan(interaction: ChatInputCommandInteraction) {
-    const serverId = interaction.guildId!;
-
-    const civToBan = interaction.options.getString("civ")!;
-    const message = await banCommand(serverId, civToBan);
-
-    await interaction.reply(message);
 }
 
 async function handleUnban(interaction: ChatInputCommandInteraction) {

--- a/src/Start.ts
+++ b/src/Start.ts
@@ -1,7 +1,7 @@
 import {Client, GatewayIntentBits} from "discord.js";
 import Messages from "./Messages";
-import { getToken } from "./Auth";
-import { handleSlashCommand } from "./Discord/SlashCommands/HandleSlashCommand";
+import {getToken} from "./Auth";
+import {handleSlashCommand} from "./Discord/SlashCommands/HandleSlashCommand";
 import {logException, logInfo} from "./Log";
 import {
     updateSlashCommandsForAllServers,
@@ -11,7 +11,7 @@ import {handleModalSubmit} from "./Discord/Modals/HandleModalSubmit";
 
 async function start() {
     const client = new Client({
-        intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates],
+        intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildVoiceStates, GatewayIntentBits.GuildMessageReactions],
     });
 
     client.once("ready", async () => {
@@ -19,14 +19,14 @@ async function start() {
         await updateSlashCommandsForAllServers(client);
         logInfo("CivBot is alive!");
     });
-    
+
     client.on("guildCreate", async (guild) => {
         logInfo(`CivBot has been added to guild ${guild.name}.`);
         logInfo("Creating slash commands...");
         await updateSlashCommandsForServer(client, guild.id);
         logInfo("Done!");
     });
-    
+
     client.on("interactionCreate", async (interaction) => {
         if (interaction.isChatInputCommand()) {
             try {
@@ -35,10 +35,13 @@ async function start() {
                 if (e instanceof Error) {
                     logException(e);
                 }
-                await interaction.reply(Messages.GenericError);
+
+                if (!interaction.replied) {
+                    await interaction.reply(Messages.GenericError);
+                }
             }
         }
-        
+
         if (interaction.isModalSubmit()) {
             try {
                 await handleModalSubmit(interaction);

--- a/src/UserData/UserSettings.ts
+++ b/src/UserData/UserSettings.ts
@@ -1,7 +1,8 @@
 import { DraftArguments } from "../Commands/Draft/DraftCommand";
+import {Civ} from "../Civs/Civs";
 
 export type UserSettings = {
     defaultDraftSettings: Partial<DraftArguments>;
     customCivs: string[];
-    bannedCivs: string[];
+    bannedCivs: Civ[];
 };


### PR DESCRIPTION
When asking to ban a civ, check to see if the string is a substring of the civ.
This way eg. "huns" will be sufficient to ban "The Huns".

Also, match civ as well as leader for Civ 6. This way when you ask to ban eg. "Russia" it will correctly ban Peter.

If there are multiple matches, the bot provides a reaction poll to have the user pick one or all of them to ban (unless there are more than, in which case it's considered not a clear match - note that there are exactly 5 civs for China).
So eg. if you want to ban Genghis Khan by typing "mongolia" but forget Kublai Khan exists, you can choose to only ban Genghis.

This all applies to unbanning too.