### PR TITLE
Don't treat custom civs like an expansion

### DIFF
--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -35,13 +35,11 @@ export function renderCivShort(civ: Civ): string {
 }
 
 function leaderHasMultipleCivs(leader: string) {
-    const flattenedCivs = (Expansions.filter((x) => x != "custom") as Exclude<Expansion, "custom">[])
-        .map((x) => Civs[x])
-        .flat();
+    const flattenedCivs = Expansions.map((x) => Civs[x]).flat();
     return flattenedCivs.filter((civ) => hasLeader(civ) && civ.leader === leader).length > 1;
 }
 
-export const Civs: { [ex in Exclude<Expansion, "custom">]: Civ[] } = {
+export const Civs: { [ex in Expansion]: Civ[] } = {
     "civ5-vanilla": [
         "America",
         "Arabia",

--- a/src/Civs/Expansions.ts
+++ b/src/Civs/Expansions.ts
@@ -9,13 +9,12 @@ export const Expansions = [
     "civ6-frontier",
     "civ6-leaderpass",
     "civ6-extra",
-    "civ6-personas",
-    "custom",
+    "civ6-personas"
 ] as const;
 
 export type Expansion = (typeof Expansions)[number];
 
-const ExpansionMetadata: { [a in Expansion]: { displayName: string; game: CivGame | "All" } } = {
+const ExpansionMetadata: { [a in Expansion]: { displayName: string; game: CivGame} } = {
     "civ5-vanilla": { displayName: "Base game + DLC", game: "Civ 5" },
     lekmod: { displayName: "LEKMOD", game: "Civ 5" },
 
@@ -25,13 +24,11 @@ const ExpansionMetadata: { [a in Expansion]: { displayName: string; game: CivGam
     "civ6-frontier": { displayName: "New Frontier Pass", game: "Civ 6" },
     "civ6-leaderpass": { displayName: "Leader Pass", game: "Civ 6" },
     "civ6-extra": { displayName: "Standalone DLC Civs", game: "Civ 6" },
-    "civ6-personas": { displayName: "Persona packs", game: "Civ 6" },
-
-    custom: { displayName: "Custom civs", game: "All" },
+    "civ6-personas": { displayName: "Persona packs", game: "Civ 6" }
 };
 
 export function expansionsInGame(game: CivGame) {
-    return Expansions.filter((x) => ExpansionMetadata[x].game === game || ExpansionMetadata[x].game === "All");
+    return Expansions.filter((x) => ExpansionMetadata[x].game === game);
 }
 
 export function displayName(expansion: Expansion) {

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -12,7 +12,7 @@ export async function showConfigCommand(interaction: ChatInputCommandInteraction
 
 function renderConfig(userData: UserData): string {
     const activeSettings = userData.userSettings[userData.game];
-    const customCivsEnabled = activeSettings.defaultDraftSettings.expansions?.includes("custom");
+    const customCivsEnabled = true;
     const anyBannedCivs = activeSettings.bannedCivs.length > 0;
 
     return `

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -12,7 +12,7 @@ export async function showConfigCommand(interaction: ChatInputCommandInteraction
 
 function renderConfig(userData: UserData): string {
     const activeSettings = userData.userSettings[userData.game];
-    const customCivsEnabled = true;
+    const anyCustomCivs = activeSettings.customCivs.length > 0;
     const anyBannedCivs = activeSettings.bannedCivs.length > 0;
 
     return `
@@ -20,15 +20,13 @@ CivBot is drafting for **${userData.game}**.
 *To change this, use \`/switch-game\`.*
 
 Enabled expansions: \`\`\`${activeSettings.defaultDraftSettings?.expansions?.map(displayName).join("\n")}\`\`\`
-${customCivsEnabled ? customCivsLine(activeSettings.customCivs) : ""}
+${anyCustomCivs ? customCivsLine(activeSettings.customCivs) : ""}
 ${anyBannedCivs ? bannedCivsLine(activeSettings.bannedCivs) : ""}
     `.trim();
 }
 
 function customCivsLine(customCivs: string[]) {
-    if (customCivs.length === 0) {
-        return "No custom civs are defined. Use `/custom-civs` to add some.\n";
-    } else if (customCivs.length > 20) {
+    if (customCivs.length > 20) {
         return `${customCivs.length} custom civs are defined. To see the full list, use \`/custom-civs\`.\n`;
     } else {
         return `Custom civs:\`\`\`${customCivs.sort().join("\n")}\`\`\``;

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -21,8 +21,7 @@ CivBot is drafting for **${userData.game}**.
 
 Enabled expansions: \`\`\`${activeSettings.defaultDraftSettings?.expansions?.map(displayName).join("\n")}\`\`\`
 ${anyCustomCivs ? customCivsLine(activeSettings.customCivs) : ""}
-${anyBannedCivs ? bannedCivsLine(activeSettings.bannedCivs) : ""}
-    `.trim();
+${anyBannedCivs ? bannedCivsLine(activeSettings.bannedCivs) : ""}`.trim();
 }
 
 function customCivsLine(customCivs: string[]) {

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -35,7 +35,7 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
 
     const draftResult = draft(players, draftArgs.numberOfCivs, civs);
 
-    await interaction.reply(generateDraftCommandOutputMessage(userData.game, draftArgs.expansions, draftResult));
+    await interaction.reply(generateDraftCommandOutputMessage(userData.game, draftArgs.expansions, userSettings.customCivs.length, draftResult));
 }
 
 function fillDefaultArguments(partialArgs: Partial<DraftArguments>, userSettings: UserSettings): DraftArguments {

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -31,7 +31,7 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
     const draftArgs = fillDefaultArguments(draftArgumentsOrError.value, userSettings);
 
     const players = voiceChannelMembers.concat(generateAiPlayers(draftArgs.numberOfAi));
-    const civs = selectCivs(draftArgs.expansions, userSettings.customCivs, userSettings.bannedCivs);
+    const civs = selectCivs(draftArgs.expansions, userSettings.bannedCivs);
 
     const draftResult = draft(players, draftArgs.numberOfCivs, civs);
 

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -31,7 +31,7 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
     const draftArgs = fillDefaultArguments(draftArgumentsOrError.value, userSettings);
 
     const players = voiceChannelMembers.concat(generateAiPlayers(draftArgs.numberOfAi));
-    const civs = selectCivs(draftArgs.expansions, userSettings.bannedCivs);
+    const civs = selectCivs(draftArgs.expansions, userSettings.bannedCivs).concat(userSettings.customCivs);
 
     const draftResult = draft(players, draftArgs.numberOfCivs, civs);
 

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -3,9 +3,13 @@ import { Draft, DraftEntry, DraftError } from "./DraftTypes";
 import { displayName, Expansion } from "../../Civs/Expansions";
 import { Result } from "../../Functional/Result";
 import { renderCivShort } from "../../Civs/Civs";
-import {CivGame} from "../../Civs/CivGames";
+import { CivGame } from "../../Civs/CivGames";
 
-export function generateDraftCommandOutputMessage(game: CivGame, expansionsUsed: Expansion[], draftResult: Result<Draft, DraftError>) {
+export function generateDraftCommandOutputMessage(
+    game: CivGame,
+    expansionsUsed: Expansion[],
+    draftResult: Result<Draft, DraftError>,
+) {
     let message = "";
     const sendMessage = (m: string) => {
         message += m + "\n";

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -8,6 +8,7 @@ import { CivGame } from "../../Civs/CivGames";
 export function generateDraftCommandOutputMessage(
     game: CivGame,
     expansionsUsed: Expansion[],
+    numberOfCustomCivs: number,
     draftResult: Result<Draft, DraftError>,
 ) {
     let message = "";
@@ -25,12 +26,18 @@ export function generateDraftCommandOutputMessage(
         if (renderDraft(draftResult.value) === "") {
             sendMessage(Messages.NoPlayers);
         } else {
-            sendMessage(`Drafting for ${game} with ${expansionsUsed.map((cg) => `\`${displayName(cg)}\``).join(", ")}`);
+            sendMessage(renderDraftDescription(game, expansionsUsed, numberOfCustomCivs));
             sendMessage(renderDraft(draftResult.value));
         }
     }
 
     return message;
+}
+
+function renderDraftDescription(game: "Civ 5" | "Civ 6", expansionsUsed: Expansion[], numberOfCustomCivs: number) {
+    const expansions = expansionsUsed.map((cg) => `\`${displayName(cg)}\``).join(", ");
+    const customCivs = numberOfCustomCivs > 0 ? ` and ${numberOfCustomCivs} custom civs` : "";
+    return `Drafting for ${game} with ${expansions}${customCivs}`;
 }
 
 function renderDraft(draft: Draft) {

--- a/src/Commands/Draft/SelectCivs.ts
+++ b/src/Commands/Draft/SelectCivs.ts
@@ -1,14 +1,9 @@
 ﻿import { Expansion } from "../../Civs/Expansions";
 import { Civ, Civs } from "../../Civs/Civs";
 
-export function selectCivs(expansions: Expansion[], customCivs: string[], bannedCivs: Civ[]): Civ[] {
+export function selectCivs(expansions: Expansion[], bannedCivs: Civ[]): Civ[] {
     return Array.from(new Set(expansions))
-        .map((expansion) => {
-            if (expansion === "custom") {
-                return customCivs;
-            }
-            return Civs[expansion];
-        })
+        .map((expansion) => Civs[expansion])
         .reduce((prev: Civ[], current: Civ[]) => current.concat(prev), [])
         .filter((x) => !bannedCivs.includes(x));
 }

--- a/src/Commands/Draft/__tests__/SelectCivs.test.ts
+++ b/src/Commands/Draft/__tests__/SelectCivs.test.ts
@@ -6,32 +6,32 @@ const customCivs = ["custom1"];
 
 describe("selectCivs", () => {
     it("should return no civs if no expansions are given", () => {
-        const civs = selectCivs([], customCivs, []);
+        const civs = selectCivs([], []);
         expect(civs).toHaveLength(0);
     });
 
     it("should return the civs of one expansion when specified", () => {
-        const civs = selectCivs(["civ5-vanilla"], customCivs, []);
+        const civs = selectCivs(["civ5-vanilla"], []);
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"]);
     });
 
     it("should include custom civs from user data if specified", () => {
-        const civs = selectCivs(["custom"], customCivs, []);
+        const civs = selectCivs([], []);
         expect(civs).toIncludeSameMembers(["custom1"]);
     });
 
     it("should return the civs of multiple expansions when specified", () => {
-        const civs = selectCivs(["civ5-vanilla", "lekmod"], customCivs, []);
+        const civs = selectCivs(["civ5-vanilla", "lekmod"], []);
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"].concat(Civs["lekmod"]));
     });
 
     it("should include custom civs with normal expansions when specified", () => {
-        const civs = selectCivs(["civ5-vanilla", "lekmod", "custom"], customCivs, []);
+        const civs = selectCivs(["civ5-vanilla", "lekmod"], []);
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"].concat(Civs["lekmod"]).concat(customCivs));
     });
 
     it("should not include banned civs", () => {
-        const civs = selectCivs(["civ5-vanilla"], [], ["Russia"]);
+        const civs = selectCivs(["civ5-vanilla"], ["Russia"]);
         expect(civs).not.toInclude("Russia");
     });
 });

--- a/src/Commands/Draft/__tests__/SelectCivs.test.ts
+++ b/src/Commands/Draft/__tests__/SelectCivs.test.ts
@@ -1,8 +1,5 @@
-import { Expansion } from "../../../Civs/Expansions";
 import { selectCivs } from "../SelectCivs";
 import { Civs } from "../../../Civs/Civs";
-
-const customCivs = ["custom1"];
 
 describe("selectCivs", () => {
     it("should return no civs if no expansions are given", () => {
@@ -15,19 +12,9 @@ describe("selectCivs", () => {
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"]);
     });
 
-    it("should include custom civs from user data if specified", () => {
-        const civs = selectCivs([], []);
-        expect(civs).toIncludeSameMembers(["custom1"]);
-    });
-
     it("should return the civs of multiple expansions when specified", () => {
         const civs = selectCivs(["civ5-vanilla", "lekmod"], []);
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"].concat(Civs["lekmod"]));
-    });
-
-    it("should include custom civs with normal expansions when specified", () => {
-        const civs = selectCivs(["civ5-vanilla", "lekmod"], []);
-        expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"].concat(Civs["lekmod"]).concat(customCivs));
     });
 
     it("should not include banned civs", () => {

--- a/src/Commands/Expansions/EnableExpansion.ts
+++ b/src/Commands/Expansions/EnableExpansion.ts
@@ -1,6 +1,6 @@
 import { Expansion, displayName, stringToExpansion } from "../../Civs/Expansions";
 import { loadUserData, saveUserData } from "../../UserDataStore";
-import { ChatInputCommandInteraction, User } from "discord.js";
+import { ChatInputCommandInteraction } from "discord.js";
 
 export async function enableExpansionCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;


### PR DESCRIPTION
Custom civs now aren't treated like an expansion and are instead always enabled. If you add custom civs, they're immediately in your draft, and you can disable them by clearing the list.