### PR TITLE
Remove expansions argument for draft command

### DIFF
--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -17,18 +17,13 @@ export type DraftArguments = {
 export async function draftCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
 
-    const draftArgumentsOrError = extractDraftArguments(interaction);
-
-    if (draftArgumentsOrError.isError) {
-        await interaction.reply(draftArgumentsOrError.error);
-        return;
-    }
+    const providedArgs = extractDraftArguments(interaction);
 
     const voiceChannelMembers = await getVoiceChannelMembers(interaction);
 
     const userData = await loadUserData(serverId);
     const userSettings = userData.userSettings[userData.game];
-    const draftArgs = fillDefaultArguments(draftArgumentsOrError.value, userSettings);
+    const draftArgs = fillDefaultArguments(providedArgs, userSettings);
 
     const players = voiceChannelMembers.concat(generateAiPlayers(draftArgs.numberOfAi));
     const civs = selectCivs(draftArgs.expansions, userSettings.customCivs, userSettings.bannedCivs);
@@ -56,59 +51,12 @@ function generateAiPlayers(numberOfAiPlayers: number) {
     return players;
 }
 
-function extractDraftArguments(interaction: ChatInputCommandInteraction): Result<Partial<DraftArguments>, string> {
+function extractDraftArguments(interaction: ChatInputCommandInteraction): Partial<DraftArguments> {
     const ai = interaction.options.getInteger("ai") ?? undefined;
     const civs = interaction.options.getInteger("civs") ?? undefined;
-    const expansionsString = interaction.options.getString("expansions") ?? undefined;
-
-    let expansions: Expansion[] | undefined = undefined;
-    if (expansionsString) {
-        let parseResult = parseExpansions(expansionsString);
-        if (!parseResult.isError) {
-            expansions = parseResult.value;
-        } else {
-            return {
-                isError: true,
-                error: `Failed to parse expansions argument - the following are not valid expansions: ${parseResult.error.invalidExpansions}`,
-            };
-        }
-    }
 
     return {
-        isError: false,
-        value: {
-            numberOfCivs: civs,
-            numberOfAi: ai,
-            expansions: expansions,
-        },
-    };
-}
-
-function parseExpansions(expansionsString: string): Result<Expansion[], { invalidExpansions: string[] }> {
-    const strings = expansionsString.split(" ");
-    const expansions: Expansion[] = [];
-    const invalidExpansions: string[] = [];
-
-    strings.forEach((string) => {
-        const expansion = stringToExpansion(string);
-        if (expansion) {
-            expansions.push(expansion);
-        } else {
-            invalidExpansions.push(string);
-        }
-    });
-
-    if (invalidExpansions.length > 0) {
-        return {
-            isError: true,
-            error: {
-                invalidExpansions: invalidExpansions,
-            },
-        };
-    }
-
-    return {
-        isError: false,
-        value: expansions,
+        numberOfCivs: civs,
+        numberOfAi: ai,
     };
 }

--- a/src/SlashCommands/SlashCommands.ts
+++ b/src/SlashCommands/SlashCommands.ts
@@ -16,12 +16,7 @@ export function getCommands(game: CivGame) {
                 type: ApplicationCommandOptionType.Integer,
                 name: "civs",
                 description: "Number of civs to draft for each player (Default is 3)",
-            },
-            {
-                type: ApplicationCommandOptionType.String,
-                name: "expansions",
-                description: "Space-separated list of expansions to include",
-            },
+            }
         ],
     };
 


### PR DESCRIPTION
This argument requires passing in a space-separated list of expansions, using the internal names that are no longer exposed to the user. As such this argument is basically unusable now. 

If discord had a better way of specifying an array as an argument (preferably with a list of options too so we can restrict it to just the expansions) we could make this usable. But it doesn't, so it's better to just get rid of this feature since it's a relic of how civbot used to work.