### PR TITLE
Allow re-rolling a draft

### DIFF
--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -79,7 +79,7 @@ function addRerollMessage(draftMessage: string, canReroll: boolean) {
     return `${draftMessage}${
         canReroll
             ? `React with 🔁 to request a re-roll. If all players request it, the draft will be re-rolled.`
-            : `Re-rolling is currently disabled since the bot does not have ManageMessages permissions.`
+            : `Re-rolling is currently disabled since the bot does not have Manage Messages permissions.`
     }`;
 }
 

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -10,6 +10,7 @@ export function generateDraftCommandOutputMessage(
     expansionsUsed: Expansion[],
     numberOfCustomCivs: number,
     draftResult: Result<Draft, DraftError>,
+    canReroll: boolean,
 ) {
     let message = "";
     const sendMessage = (m: string) => {
@@ -28,6 +29,15 @@ export function generateDraftCommandOutputMessage(
         } else {
             sendMessage(renderDraftDescription(game, expansionsUsed, numberOfCustomCivs));
             sendMessage(renderDraft(draftResult.value));
+
+            if (canReroll) {
+                sendMessage(
+                    `React with 🔁 to request a re-roll. If all players request it, the draft will be re-rolled.`,
+                );
+            }
+            else {
+                sendMessage("Re-rolling is currently disabled since the bot does not have ManageMessages permissions.")
+            }
         }
     }
 

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -5,12 +5,11 @@ import { Result } from "../../Functional/Result";
 import { renderCivShort } from "../../Civs/Civs";
 import { CivGame } from "../../Civs/CivGames";
 
-export function generateDraftCommandOutputMessage(
+export function generateDraftMessage(
     game: CivGame,
     expansionsUsed: Expansion[],
     numberOfCustomCivs: number,
-    draftResult: Result<Draft, DraftError>,
-    canReroll: boolean,
+    draftResult: Result<Draft, DraftError>
 ) {
     let message = "";
     const sendMessage = (m: string) => {
@@ -29,15 +28,6 @@ export function generateDraftCommandOutputMessage(
         } else {
             sendMessage(renderDraftDescription(game, expansionsUsed, numberOfCustomCivs));
             sendMessage(renderDraft(draftResult.value));
-
-            if (canReroll) {
-                sendMessage(
-                    `React with 🔁 to request a re-roll. If all players request it, the draft will be re-rolled.`,
-                );
-            }
-            else {
-                sendMessage("Re-rolling is currently disabled since the bot does not have ManageMessages permissions.")
-            }
         }
     }
 


### PR DESCRIPTION
Players can now vote to re-roll a draft, which will just replace the draft in-place with a fresh one.
All players involved in the draft must vote to re-roll before the draft is re-rolled. If there are no voice players in the draft, only the user who invoked civbot needs to vote.

Note - this requires Manage Messages permissions to remove the reactions after the re-roll. If that permission is missing, re-rolls are disabled and the bot will tell you why.