### PR TITLE
Introduce tests using a mocked discord interaction (and fix a bug with selectCivs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "civ-bot",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "civ-bot",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "discord.js": "^14.15.2",
         "eslint": "^9.2.0",
@@ -22,6 +22,7 @@
         "@types/node-fetch": "^2.6.11",
         "@types/pg": "^8.11.6",
         "@types/shuffle-array": "^1.0.5",
+        "@typestrong/ts-mockito": "^2.7.12",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
         "prettier": "3.2.5",
@@ -308,19 +309,21 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -434,10 +437,14 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-      "integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -658,14 +665,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
-      "integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1556,6 +1563,18 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
+    },
+    "node_modules/@typestrong/ts-mockito": {
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/@typestrong/ts-mockito/-/ts-mockito-2.7.12.tgz",
+      "integrity": "sha512-dvgtwC0MR2q6/GFZs3HvJzRjgLNb4N3/WiG/Ay6v8fyv6o4QkqoAQl9Lqzr+hK3G1MAazdCFxJiLjT79+51ysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.24.7",
+        "lodash": "^4.17.5",
+        "safe-json-stringify": "^1.2.0"
+      }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
       "version": "2.2.4",
@@ -4640,6 +4659,13 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4858,15 +4884,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node-fetch": "^2.6.11",
     "@types/pg": "^8.11.6",
     "@types/shuffle-array": "^1.0.5",
+    "@typestrong/ts-mockito": "^2.7.12",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",
     "prettier": "3.2.5",

--- a/src/Civs/SelectCivs.ts
+++ b/src/Civs/SelectCivs.ts
@@ -1,9 +1,9 @@
 ﻿import { Expansion } from "./Expansions";
-import { Civ, Civs } from "./Civs";
+import {Civ, Civs, civsEqual} from "./Civs";
 
 export function selectCivs(expansions: Expansion[], excludedCivs: Civ[]): Civ[] {
     return Array.from(new Set(expansions))
         .map((expansion) => Civs[expansion])
         .reduce((prev: Civ[], current: Civ[]) => current.concat(prev), [])
-        .filter((x) => !excludedCivs.includes(x));
+        .filter((x) => !excludedCivs.some(y => civsEqual(x, y)));
 }

--- a/src/Commands/Ban/__tests__/BanCommand.test.ts
+++ b/src/Commands/Ban/__tests__/BanCommand.test.ts
@@ -8,40 +8,90 @@ describe("BanCommand", () => {
         await clearTestUserData();
     })
 
-    it("should ban the specified civ", async () => {
-        const interaction = TestInteraction.ban("Russia");
+    describe("Civ 5", () => {
+        it("should ban the specified civ", async () => {
+            const interaction = TestInteraction.ban("Russia");
 
-        await banCommand(interaction.value);
-        
-        const userData = await getTestUserData();
+            await banCommand(interaction.value);
 
-        expect(interaction.output).not.toBeEmpty();
-        expect(userData.userSettings["Civ 5"].bannedCivs).toEqual(["Russia"]);
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 5"].bannedCivs).toEqual(["Russia"]);
+        });
+
+        it("should not ban the civ if the civ is already banned", async () => {
+            await banCommand(TestInteraction.ban("Rome").value);
+
+            const interaction = TestInteraction.ban("Rome");
+            await banCommand(interaction.value);
+
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 5"].bannedCivs).toEqual(["Rome"]);
+        });
+
+        it("should not ban the civ if it doesn't exist", async () => {
+            const interaction = TestInteraction.ban("ThisCivDoesNotExistOhNooooo");
+            await banCommand(interaction.value);
+
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 5"].bannedCivs).toEqual([]);
+        });
     });
 
-    it("should ban based on civ name for Civ 6", async () => {
-        await switchGameCommand(TestInteraction.empty().value);
+    describe("Civ 6", () => {
+        beforeEach(async () => {
+            await switchGameCommand(TestInteraction.empty().value);
+        });
 
-        const interaction = TestInteraction.ban("Russia");
+        it("should ban based on civ name", async () => {
+            const interaction = TestInteraction.ban("Russia");
 
-        await banCommand(interaction.value);
-        
-        const userData = await getTestUserData();
-        
-        expect(interaction.output).not.toBeEmpty();
-        expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Peter", civ: "Russia"}]);
+            await banCommand(interaction.value);
+
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Peter", civ: "Russia"}]);
+        });
+
+        it("should ban based on leader name", async () => {
+            const interaction = TestInteraction.ban("Trajan");
+
+            await banCommand(interaction.value);
+
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Trajan", civ: "Rome"}]);
+        });
+
+        it("should not ban the civ if the civ is already banned", async () => {
+            await banCommand(TestInteraction.ban("Trajan").value);
+
+            const interaction = TestInteraction.ban("Trajan");
+            await banCommand(interaction.value);
+
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Trajan", civ: "Rome"}]);
+        });
+
+        it("should not ban the civ if it doesn't exist", async () => {
+            const interaction = TestInteraction.ban("ThisCivDoesNotExistOhNooooo");
+            await banCommand(interaction.value);
+
+            const userData = await getTestUserData();
+
+            expect(interaction.output).not.toBeEmpty();
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([]);
+        });
     });
 
-    it("should ban based on leader name for Civ 6", async () => {
-        await switchGameCommand(TestInteraction.empty().value);
 
-        const interaction = TestInteraction.ban("Trajan");
-
-        await banCommand(interaction.value);
-
-        const userData = await getTestUserData();
-        
-        expect(interaction.output).not.toBeEmpty();
-        expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Trajan", civ: "Rome"}]);
-    });
 });

--- a/src/Commands/Ban/__tests__/BanCommand.test.ts
+++ b/src/Commands/Ban/__tests__/BanCommand.test.ts
@@ -1,0 +1,54 @@
+import {clearTestUserData, getTestUserData} from "../../../TestUtilities/TestUserData";
+import {TestInteraction} from "../../../TestUtilities/TestInteraction";
+import {when} from "@typestrong/ts-mockito";
+import {banCommand} from "../BanCommand";
+import {switchGameCommand} from "../../SwitchGame/SwitchGameCommand";
+
+describe("BanCommand", () => {
+    beforeEach(async () => {
+        await clearTestUserData();
+    })
+
+    it("should ban the specified civ", async () => {
+        const interaction = new TestInteraction((options) => {
+            when(options.getString("civ")).thenReturn("Russia")
+        });
+
+        await banCommand(interaction.value);
+        
+        const userData = await getTestUserData();
+
+        expect(interaction.output).not.toBeEmpty();
+        expect(userData.userSettings["Civ 5"].bannedCivs).toEqual(["Russia"]);
+    });
+
+    it("should ban based on civ name for Civ 6", async () => {
+        await switchGameCommand(TestInteraction.createEmpty().value);
+        
+        const interaction = new TestInteraction((options) => {
+            when(options.getString("civ")).thenReturn("Russia")
+        });
+
+        await banCommand(interaction.value);
+        
+        const userData = await getTestUserData();
+        
+        expect(interaction.output).not.toBeEmpty();
+        expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Peter", civ: "Russia"}]);
+    });
+
+    it("should ban based on leader name for Civ 6", async () => {
+        await switchGameCommand(TestInteraction.createEmpty().value);
+
+        const interaction = new TestInteraction((options) => {
+            when(options.getString("civ")).thenReturn("Trajan")
+        });
+
+        await banCommand(interaction.value);
+
+        const userData = await getTestUserData();
+        
+        expect(interaction.output).not.toBeEmpty();
+        expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Trajan", civ: "Rome"}]);
+    });
+});

--- a/src/Commands/Ban/__tests__/BanCommand.test.ts
+++ b/src/Commands/Ban/__tests__/BanCommand.test.ts
@@ -1,6 +1,5 @@
 import {clearTestUserData, getTestUserData} from "../../../TestUtilities/TestUserData";
 import {TestInteraction} from "../../../TestUtilities/TestInteraction";
-import {when} from "@typestrong/ts-mockito";
 import {banCommand} from "../BanCommand";
 import {switchGameCommand} from "../../SwitchGame/SwitchGameCommand";
 
@@ -10,9 +9,7 @@ describe("BanCommand", () => {
     })
 
     it("should ban the specified civ", async () => {
-        const interaction = new TestInteraction((options) => {
-            when(options.getString("civ")).thenReturn("Russia")
-        });
+        const interaction = TestInteraction.ban("Russia");
 
         await banCommand(interaction.value);
         
@@ -23,11 +20,9 @@ describe("BanCommand", () => {
     });
 
     it("should ban based on civ name for Civ 6", async () => {
-        await switchGameCommand(TestInteraction.createEmpty().value);
-        
-        const interaction = new TestInteraction((options) => {
-            when(options.getString("civ")).thenReturn("Russia")
-        });
+        await switchGameCommand(TestInteraction.empty().value);
+
+        const interaction = TestInteraction.ban("Russia");
 
         await banCommand(interaction.value);
         
@@ -38,11 +33,9 @@ describe("BanCommand", () => {
     });
 
     it("should ban based on leader name for Civ 6", async () => {
-        await switchGameCommand(TestInteraction.createEmpty().value);
+        await switchGameCommand(TestInteraction.empty().value);
 
-        const interaction = new TestInteraction((options) => {
-            when(options.getString("civ")).thenReturn("Trajan")
-        });
+        const interaction = TestInteraction.ban("Trajan");
 
         await banCommand(interaction.value);
 

--- a/src/Commands/SwitchGame/__tests__/SwitchGameCommand.test.ts
+++ b/src/Commands/SwitchGame/__tests__/SwitchGameCommand.test.ts
@@ -1,0 +1,31 @@
+import {switchGameCommand} from "../SwitchGameCommand";
+import {clearTestUserData, getTestUserData} from "../../../TestUtilities/TestUserData";
+import {TestInteraction} from "../../../TestUtilities/TestInteraction";
+
+describe("switch game", () => {
+    beforeEach(async () => {
+        await clearTestUserData();
+    })
+
+    it("should switch to Civ 6 when in Civ 5 mode", async () => {
+        const testInteraction = new TestInteraction();
+        await switchGameCommand(testInteraction.value);
+
+        const userData = await getTestUserData();
+
+        expect(userData.game).toBe("Civ 6");
+        expect(testInteraction.output).toEqual(["Switched to drafting for Civ 6."])
+    });
+
+    it("should switch to Civ 5 when in Civ 6 mode", async () => {
+        await switchGameCommand(new TestInteraction().value);
+
+        const testInteraction = new TestInteraction();
+        await switchGameCommand(testInteraction.value);
+
+        const userData = await getTestUserData();
+
+        expect(userData.game).toBe("Civ 5");
+        expect(testInteraction.output).toEqual(["Switched to drafting for Civ 5."])
+    });
+});

--- a/src/Commands/SwitchGame/__tests__/SwitchGameCommand.test.ts
+++ b/src/Commands/SwitchGame/__tests__/SwitchGameCommand.test.ts
@@ -8,7 +8,7 @@ describe("switch game", () => {
     })
 
     it("should switch to Civ 6 when in Civ 5 mode", async () => {
-        const testInteraction = new TestInteraction();
+        const testInteraction = new TestInteraction(() => {});
         await switchGameCommand(testInteraction.value);
 
         const userData = await getTestUserData();
@@ -18,9 +18,9 @@ describe("switch game", () => {
     });
 
     it("should switch to Civ 5 when in Civ 6 mode", async () => {
-        await switchGameCommand(new TestInteraction().value);
+        await switchGameCommand(new TestInteraction(() => {}).value);
 
-        const testInteraction = new TestInteraction();
+        const testInteraction = new TestInteraction(() => {});
         await switchGameCommand(testInteraction.value);
 
         const userData = await getTestUserData();

--- a/src/Commands/SwitchGame/__tests__/SwitchGameCommand.test.ts
+++ b/src/Commands/SwitchGame/__tests__/SwitchGameCommand.test.ts
@@ -8,7 +8,7 @@ describe("switch game", () => {
     })
 
     it("should switch to Civ 6 when in Civ 5 mode", async () => {
-        const testInteraction = new TestInteraction(() => {});
+        const testInteraction = TestInteraction.empty();
         await switchGameCommand(testInteraction.value);
 
         const userData = await getTestUserData();
@@ -18,9 +18,9 @@ describe("switch game", () => {
     });
 
     it("should switch to Civ 5 when in Civ 6 mode", async () => {
-        await switchGameCommand(new TestInteraction(() => {}).value);
+        await switchGameCommand(TestInteraction.empty().value);
 
-        const testInteraction = new TestInteraction(() => {});
+        const testInteraction = TestInteraction.empty();
         await switchGameCommand(testInteraction.value);
 
         const userData = await getTestUserData();

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -11,5 +11,7 @@ export function logException(error: Error) {
 }
 
 function logMessage(level: string, message: string) {
-    console.error(`[${new Date(Date.now()).toISOString()}] ${level}: ${message}`);
+    let fullMessage = `[${new Date(Date.now()).toISOString()}] ${level}: ${message}`;
+    
+    level === "ERROR" ? console.log(message) : console.log(fullMessage);
 }

--- a/src/TestUtilities/TestInteraction.ts
+++ b/src/TestUtilities/TestInteraction.ts
@@ -29,8 +29,14 @@ export class TestInteraction {
         this.output = [...this.output, message];
     }
 
-    public static createEmpty() {
+    public static empty() {
         return new TestInteraction(() => {
         });
+    }
+    
+    public static ban(civ: string) {
+        return new TestInteraction(options => {
+            when(options.getString("civ")).thenReturn(civ);
+        })
     }
 }

--- a/src/TestUtilities/TestInteraction.ts
+++ b/src/TestUtilities/TestInteraction.ts
@@ -1,11 +1,11 @@
-import {ChatInputCommandInteraction, Client, Message} from "discord.js";
+import {ChatInputCommandInteraction, Client, CommandInteractionOptionResolver, Message} from "discord.js";
 import {anyString, instance, mock, when} from "@typestrong/ts-mockito";
 
 export class TestInteraction {
     public output: string[] = []
     public value: ChatInputCommandInteraction;
 
-    constructor() {
+    constructor(applyOptions: (options: CommandInteractionOptionResolver) => void) {
         let messageMock = mock(Message);
         let mockedInteraction = mock(ChatInputCommandInteraction);
         when(mockedInteraction.guildId).thenReturn("test-guild");
@@ -13,6 +13,11 @@ export class TestInteraction {
             this.writeMessage(message);
             return instance(messageMock);
         });
+
+        const mockedOptions = mock(CommandInteractionOptionResolver);
+        applyOptions(mockedOptions);
+        when(mockedInteraction.options).thenReturn(instance(mockedOptions));
+
         let mockedClient = mock(Client);
         when(mockedClient.application).thenReturn(null);
         when(mockedInteraction.client).thenReturn(instance(mockedClient));
@@ -22,5 +27,10 @@ export class TestInteraction {
 
     private writeMessage(message: string) {
         this.output = [...this.output, message];
+    }
+
+    public static createEmpty() {
+        return new TestInteraction(() => {
+        });
     }
 }

--- a/src/TestUtilities/TestInteraction.ts
+++ b/src/TestUtilities/TestInteraction.ts
@@ -1,0 +1,26 @@
+import {ChatInputCommandInteraction, Client, Message} from "discord.js";
+import {anyString, instance, mock, when} from "@typestrong/ts-mockito";
+
+export class TestInteraction {
+    public output: string[] = []
+    public value: ChatInputCommandInteraction;
+
+    constructor() {
+        let messageMock = mock(Message);
+        let mockedInteraction = mock(ChatInputCommandInteraction);
+        when(mockedInteraction.guildId).thenReturn("test-guild");
+        when(mockedInteraction.reply(anyString())).thenCall(async (message: string) => {
+            this.writeMessage(message);
+            return instance(messageMock);
+        });
+        let mockedClient = mock(Client);
+        when(mockedClient.application).thenReturn(null);
+        when(mockedInteraction.client).thenReturn(instance(mockedClient));
+
+        this.value = instance(mockedInteraction);
+    }
+
+    private writeMessage(message: string) {
+        this.output = [...this.output, message];
+    }
+}

--- a/src/TestUtilities/TestInteraction.ts
+++ b/src/TestUtilities/TestInteraction.ts
@@ -16,7 +16,7 @@ export class TestInteraction {
 
         const mockedOptions = mock(CommandInteractionOptionResolver);
         applyOptions(mockedOptions);
-        when(mockedInteraction.options).thenReturn(instance(mockedOptions));
+        when(mockedInteraction.options).thenReturn(instance(mockedOptions) as Omit<CommandInteractionOptionResolver, 'getMessage' | 'getFocused'>);
 
         let mockedClient = mock(Client);
         when(mockedClient.application).thenReturn(null);
@@ -33,7 +33,7 @@ export class TestInteraction {
         return new TestInteraction(() => {
         });
     }
-    
+
     public static ban(civ: string) {
         return new TestInteraction(options => {
             when(options.getString("civ")).thenReturn(civ);

--- a/src/TestUtilities/TestUserData.ts
+++ b/src/TestUtilities/TestUserData.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs";
+import {loadUserData} from "../UserDataStore";
+
+export async function clearTestUserData() {
+    await fs.promises.rm("./userdata/test-guild.json");
+}
+
+export async function getTestUserData() {
+    return await loadUserData("test-guild");
+}

--- a/src/TestUtilities/TestUserData.ts
+++ b/src/TestUtilities/TestUserData.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import {loadUserData} from "../UserDataStore";
 
 export async function clearTestUserData() {
-    await fs.promises.rm("./userdata/test-guild.json");
+    await fs.promises.rm("./userdata/test-guild.json", {force: true})
 }
 
 export async function getTestUserData() {


### PR DESCRIPTION
Introduces tests using ts-mockito that use mocked interactions, so we can continue using discord interactions directly in the code while still having tests.

These tests caught a bug with selectCivs which meant the ban functionality didn't work properly for civ 6, so this has been fixed.

This only covers a few commands so far - draft will be more involved. The tests can be expanded in future.