### PR TITLE
Use the display name for players instead of their username

### DIFF
--- a/src/Discord/VoiceChannels.ts
+++ b/src/Discord/VoiceChannels.ts
@@ -16,7 +16,7 @@ export async function getVoiceChannelMembers(interaction: CommandInteraction): P
     if (member instanceof GuildMember) {
         voiceChannel = await getVoiceChannel(interaction.client, member);
         if (voiceChannel) {
-            return voiceChannel.members.map((m) => m.user.username);
+            return voiceChannel.members.map((m) => m.displayName);
         }
     }
 


### PR DESCRIPTION
The change to discord usernames meant that the player names ended up being the "unique string" which doesn't necessarily match the shown username. Now we use displayName, which should be the username or server nickname.