### PR TITLE
Force the tests to run serially

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "dev": "ts-node src/Start.ts",
-    "test": "jest",
+    "test": "jest --runInBand",
     "build": "tsc",
     "start": "node build/Start.js"
   }


### PR DESCRIPTION
The tests currently use a file for the user data store, just to avoid dealing with mocking it out. But this leads to the tests being super flaky if run in parallel. This should be a quick fix to force the tests to run serially so this doesn't happen. We'll want to do this properly at some point though.