### PR TITLE
Add an option to guarantee coastal civs

### DIFF
--- a/src/Civs/Civs.ts
+++ b/src/Civs/Civs.ts
@@ -1,56 +1,57 @@
-import { Expansion, Expansions } from "./Expansions";
+import {Expansion, Expansions, gameOfExpansion} from "./Expansions";
+import {CivGame} from "./CivGames";
 
-export type Civ = string | { leader: string; civ: string };
+export type CivIdFrom<E extends Expansion> = typeof Civs[E][number]
+export type CivId = CivIdFrom<Expansion>
 
-export function hasLeader(civ: Civ): civ is { leader: string; civ: string } {
-    return !(typeof civ === "string");
+export type Civ = {
+    civ: string;
+    leader: string;
+    coastal: boolean;
 }
 
-export function civsEqual(a: Civ, b: Civ) {
-    if (!hasLeader(a) || !hasLeader(b)) {
-        return a === b;
-    }
-
-    return a.leader === b.leader && a.civ === b.civ;
+export function getCiv(id: CivId) {
+    return CivData[id];
 }
 
-export function renderCiv(civ: Civ): string {
-    if (!hasLeader(civ)) {
-        return civ;
+export function renderCiv(civ: Civ, civGame: CivGame): string {
+    if (civGame === "Civ 5") {
+        return civ.civ;
     }
 
     return `${civ.leader} - ${civ.civ}`;
 }
 
-export function renderCivShort(civ: Civ): string {
-    if (!hasLeader(civ)) {
-        return civ;
+export function renderCivShort(civ: Civ, civGame: CivGame): string {
+    if (civGame === "Civ 5") {
+        return civ.civ;
     }
 
-    if (leaderHasMultipleCivs(civ.leader)) {
+    if (civ6LeaderHasMultipleCivs(civ.leader)) {
         return `${civ.leader} (${civ.civ})`;
     }
 
     return civ.leader;
 }
 
-function leaderHasMultipleCivs(leader: string) {
-    const flattenedCivs = Expansions.map((x) => Civs[x]).flat();
-    return flattenedCivs.filter((civ) => hasLeader(civ) && civ.leader === leader).length > 1;
+function civ6LeaderHasMultipleCivs(leader: string) {
+    const flattenedCivs = Expansions.filter(x => gameOfExpansion(x) === "Civ 6")
+        .map((x) => Civs[x]).flat().map(x => CivData[x]);
+    return flattenedCivs.filter((civ) => civ.leader === leader).length > 1;
 }
 
-export const Civs: { [ex in Expansion]: Civ[] } = {
+export const Civs = {
     "civ5-vanilla": [
         "America",
         "Arabia",
         "Assyria",
         "Austria",
-        "The Aztecs",
+        "Aztecs",
         "Babylon",
         "Brazil",
         "Byzantium",
         "Carthage",
-        "The Celts",
+        "Celts",
         "China",
         "Denmark",
         "Netherlands",
@@ -60,29 +61,29 @@ export const Civs: { [ex in Expansion]: Civ[] } = {
         "France",
         "Germany",
         "Greece",
-        "The Huns",
-        "The Inca",
+        "Huns",
+        "Inca",
         "India",
         "Indonesia",
-        "The Iroquois",
+        "Iroquois",
         "Japan",
         "Korea",
-        "The Maya",
+        "Maya",
         "Mongolia",
         "Morocco",
-        "The Ottomans",
+        "Ottomans",
         "Persia",
         "Poland",
         "Polynesia",
         "Portugal",
         "Rome",
         "Russia",
-        "The Shoshone",
+        "Shoshone",
         "Siam",
         "Songhai",
         "Spain",
         "Sweden",
-        "The Zulu",
+        "Zulu",
     ],
 
     lekmod: [
@@ -121,7 +122,7 @@ export const Civs: { [ex in Expansion]: Civ[] } = {
         "Macedonia",
         "Madagascar",
         "Manchuria",
-        "The Maori",
+        "Maori",
         "Maurya",
         "Mexico",
         "Moors",
@@ -134,7 +135,7 @@ export const Civs: { [ex in Expansion]: Civ[] } = {
         "Oman",
         "Palmyra",
         "Papal State",
-        "Pheonicia",
+        "Phoenicia",
         "Philippines",
         "Prussia",
         "Romania",
@@ -148,7 +149,6 @@ export const Civs: { [ex in Expansion]: Civ[] } = {
         "Turkey",
         "U.A.E",
         "Ukraine",
-        "Vatican",
         "Venice",
         "Vietnam",
         "Wales",
@@ -157,331 +157,295 @@ export const Civs: { [ex in Expansion]: Civ[] } = {
     ],
 
     "civ6-vanilla": [
-        {
-            leader: "Catherine de Medici (Black Queen)",
-            civ: "France",
-        },
-        {
-            leader: "Cleopatra (Egyptian)",
-            civ: "Egypt",
-        },
-        {
-            leader: "Frederick Barbarossa",
-            civ: "Germany",
-        },
-        {
-            leader: "Gandhi",
-            civ: "India",
-        },
-        {
-            leader: "Gilgamesh",
-            civ: "Sumeria",
-        },
-        {
-            leader: "Gorgo",
-            civ: "Greece",
-        },
-        {
-            leader: "Harald Hardrada (Konge)",
-            civ: "Norway",
-        },
-        {
-            leader: "Hojo Tokimune",
-            civ: "Japan",
-        },
-        {
-            leader: "Julius Caesar",
-            civ: "Rome",
-        },
-        {
-            leader: "Montezuma",
-            civ: "Aztec",
-        },
-        {
-            leader: "Mvemba a Nzinga",
-            civ: "Kongo",
-        },
-        {
-            leader: "Pedro II",
-            civ: "Brazil",
-        },
-        {
-            leader: "Pericles",
-            civ: "Greece",
-        },
-        {
-            leader: "Peter",
-            civ: "Russia",
-        },
-        {
-            leader: "Philip II",
-            civ: "Spain",
-        },
-        {
-            leader: "Qin Shi Huang (Mandate of Heaven)",
-            civ: "China",
-        },
-        {
-            leader: "Saladin (Vizier)",
-            civ: "Arabia",
-        },
-        {
-            leader: "Teddy Roosevelt (Bull Moose)",
-            civ: "America",
-        },
-        {
-            leader: "Tomyris",
-            civ: "Scythia",
-        },
-        {
-            leader: "Trajan",
-            civ: "Rome",
-        },
-        {
-            leader: "Victoria (Age of Empire)",
-            civ: "England",
-        },
+        "CatherineDeMediciBlackQueen",
+        "CleopatraEgyptian",
+        "FrederickBarbarossa",
+        "Gandhi",
+        "Gilgamesh",
+        "Gorgo",
+        "HaraldHardradaKonge",
+        "HojoTokimune",
+        "JuliusCaesar",
+        "Monetuzuma",
+        "MvembaANzinga",
+        "PedroII",
+        "Pericles",
+        "Peter",
+        "PhilipII",
+        "QinShiHuangMandate",
+        "SaladinVizier",
+        "TeddyBullMoose",
+        "Tomyris",
+        "Trajan",
+        "VictoriaEmpire",
     ],
 
     "civ6-rnf": [
-        {
-            leader: "Chandragupta",
-            civ: "India",
-        },
-        {
-            leader: "Genghis Khan",
-            civ: "Mongolia",
-        },
-        {
-            leader: "Lautaro",
-            civ: "Mapuche",
-        },
-        {
-            leader: "Poundmaker",
-            civ: "Cree",
-        },
-        {
-            leader: "Robert the Bruce",
-            civ: "Scotland",
-        },
-        {
-            leader: "Seondeok",
-            civ: "Korea",
-        },
-        {
-            leader: "Shaka",
-            civ: "Zulu",
-        },
-        {
-            leader: "Tamar",
-            civ: "Georgia",
-        },
-        {
-            leader: "Wilhelmina",
-            civ: "The Netherlands",
-        },
+        "Chandragupta",
+        "GenghisKhan",
+        "Lautaro",
+        "Poundmaker",
+        "RobertTheBruce",
+        "Seondeok",
+        "Shaka",
+        "Tamar",
+        "Wilhelmina",
     ],
 
     "civ6-gs": [
-        {
-            leader: "Dido",
-            civ: "Carthage",
-        },
-        {
-            leader: "Eleanor of Aquitaine",
-            civ: "England",
-        },
-        {
-            leader: "Eleanor of Aquitaine",
-            civ: "France",
-        },
-        {
-            leader: "Kristina",
-            civ: "Sweden",
-        },
-        {
-            leader: "Kupe",
-            civ: "The Maori",
-        },
-        {
-            leader: "Mansa Musa",
-            civ: "Mali",
-        },
-        {
-            leader: "Matthias Corvinus",
-            civ: "Hungary",
-        },
-        {
-            leader: "Pachacuti",
-            civ: "The Inca",
-        },
-        {
-            leader: "Suleiman (Kanuni)",
-            civ: "The Ottomans",
-        },
-        {
-            leader: "Wilfred Laurier",
-            civ: "Canada",
-        },
+        "Dido",
+        "Eleanor_England",
+        "Eleanor_France",
+        "Kristina",
+        "Kupe",
+        "MansaMusa",
+        "MatthiasCorvinus",
+        "Pachacuti",
+        "SuleimanKanuni",
+        "WilfredLaurier",
     ],
 
     "civ6-frontier": [
-        {
-            leader: "Ambiorix",
-            civ: "Gaul",
-        },
-        {
-            leader: "Basil II",
-            civ: "Byzantium",
-        },
-        {
-            leader: "Bà Triệu",
-            civ: "Vietnam",
-        },
-        {
-            leader: "Hammurabi",
-            civ: "Babylon",
-        },
-        {
-            leader: "João III",
-            civ: "Portugal",
-        },
-        {
-            leader: "Kublai Khan",
-            civ: "China",
-        },
-        {
-            leader: "Kublai Khan",
-            civ: "Mongolia",
-        },
-        {
-            leader: "Lady Six Sky",
-            civ: "Maya",
-        },
-        {
-            leader: "Menelik II",
-            civ: "Ethiopia",
-        },
-        {
-            leader: "Simón Bolívar",
-            civ: "Gran Colombia",
-        },
+        "Ambiorix",
+        "BasilII",
+        "BaTrieu",
+        "Hammurabi",
+        "JoaoIII",
+        "KublaiKhan_China",
+        "KublaiKhan_Mongolia",
+        "LadySixSky",
+        "MenelikII",
+        "SimonBolivar",
     ],
 
     "civ6-leaderpass": [
-        {
-            leader: "Abraham Lincoln",
-            civ: "America",
-        },
-        {
-            leader: "Cleopatra (Ptolemaic)",
-            civ: "Egypt",
-        },
-        {
-            leader: "Elizabeth I",
-            civ: "England",
-        },
-        {
-            leader: "Harald Hardrada (Varangian)",
-            civ: "Norway",
-        },
-        {
-            leader: "Ludwig II",
-            civ: "Germany",
-        },
-        {
-            leader: "Nader Shah",
-            civ: "Persia",
-        },
-        {
-            leader: "Nzinga Mbande",
-            civ: "Kongo",
-        },
-        {
-            leader: "Qin Shi Huang (Unifier)",
-            civ: "China",
-        },
-        {
-            leader: "Ramses II",
-            civ: "Egypt",
-        },
-        {
-            leader: "Saladin (Sultan)",
-            civ: "Arabia",
-        },
-        {
-            leader: "Sejong",
-            civ: "Korea",
-        },
-        {
-            leader: "Suleiman (Muhtesem)",
-            civ: "The Ottomans",
-        },
-        {
-            leader: "Sundiata Keita",
-            civ: "Mali",
-        },
-        {
-            leader: "Theodora",
-            civ: "Byzantium",
-        },
-        {
-            leader: "Tokugawa",
-            civ: "Japan",
-        },
-        {
-            leader: "Victoria (Age of Steam)",
-            civ: "England",
-        },
-        {
-            leader: "Wu Zetian",
-            civ: "China",
-        },
-        {
-            leader: "Yongle",
-            civ: "China",
-        },
+        "AbrahamLincoln",
+        "CleopatraPtolemaic",
+        "ElizabethI",
+        "HaraldHardradaVarangian",
+        "LudwigII",
+        "NaderShah",
+        "NzingaMbande",
+        "QinShiHuangUnifier",
+        "RamsesII",
+        "SaladinSultan",
+        "Sejong",
+        "SuleimanMuhtesem",
+        "SundiataKeita",
+        "Theodora",
+        "Tokugawa",
+        "VictoriaSteam",
+        "WuZetian",
+        "Yongle",
+
     ],
 
     "civ6-extra": [
-        {
-            leader: "Alexander",
-            civ: "Macedon",
-        },
-        {
-            leader: "Amanitore",
-            civ: "Nubia",
-        },
-        {
-            leader: "Cyrus",
-            civ: "Persia",
-        },
-        {
-            leader: "Gitarja",
-            civ: "Indonesia",
-        },
-        {
-            leader: "Jadwiga",
-            civ: "Poland",
-        },
-        {
-            leader: "Jayavarman VII",
-            civ: "Khmer",
-        },
-        {
-            leader: "John Curtin",
-            civ: "Australia",
-        },
+        "Alexander",
+        "Amanitore",
+        "Cyrus",
+        "Gitarja",
+        "Jadwiga",
+        "JayavarmanVII",
+        "JohnCurtin",
+
     ],
 
     "civ6-personas": [
-        {
-            leader: "Catherine de Medici (Magnificence)",
-            civ: "France",
-        },
-        {
-            leader: "Teddy Roosevelt (Rough Rider)",
-            civ: "America",
-        },
+        "CatherineDeMediciMagnificence",
+        "TeddyRoughRider",
     ],
-};
+} as const satisfies { [ex in Expansion]: string[] };
+
+const CivData: { [civ in CivId]: Civ } = {
+
+    // Civ 5
+    "Akkad": {civ: "Akkad", leader: "Sargon", coastal: false},
+    "Akzum": {civ: "Akzum", leader: "Ezana", coastal: false},
+    "America": {civ: "America", leader: "Washington", coastal: false},
+    "Arabia": {civ: "Arabia", leader: "Harun al-Rashid", coastal: false},
+    "Argentina": {civ: "Argentina", leader: "Eva Perón", coastal: false},
+    "Armenia": {civ: "Armenia", leader: "Tiridates III", coastal: false},
+    "Assyria": {civ: "Assyria", leader: "Ashurbanipal", coastal: false},
+    "Australia": {civ: "Australia", leader: "Henry Parker", coastal: true},
+    "Austria": {civ: "Austria", leader: "Maria Theresa", coastal: false},
+    "Ayyubids": {civ: "Ayyubids", leader: "Saladin", coastal: false},
+    "Aztecs": {civ: "The Aztecs", leader: "Montezuma", coastal: false},
+    "Babylon": {civ: "Babylon", leader: "Nebuchadnezzar II", coastal: false},
+    "Belgium": {civ: "Belgium", leader: "", coastal: false},
+    "Boers": {civ: "Boers", leader: "Stephanus Johannes Paulus Kruger", coastal: false},
+    "Bolivia": {civ: "Bolivia", leader: "Tata Belzu", coastal: false},
+    "Brazil": {civ: "Brazil", leader: "Pedro II", coastal: false},
+    "Brunei": {civ: "Brunei", leader: "Bolkiah", coastal: true},
+    "Bulgaria": {civ: "Bulgaria", leader: "Asparukh Khan", coastal: false},
+    "Burma": {civ: "Burma", leader: "Anawrahta", coastal: false},
+    "Byzantium": {civ: "Byzantium", leader: "Theodora", coastal: false},
+    "Canada": {civ: "Canada", leader: "John A. MacDonald", coastal: false},
+    "Carthage": {civ: "Carthage", leader: "Dido", coastal: true},
+    "Celts": {civ: "The Celts", leader: "Boudicca", coastal: false},
+    "Chile": {civ: "Chile", leader: "Bernardo O’ Higgens", coastal: true},
+    "China": {civ: "China", leader: "Wu Zetian", coastal: false},
+    "Colombia": {civ: "Colombia", leader: "Simon Bolivar", coastal: false},
+    "Cuba": {civ: "Cuba", leader: "Fidel Castro", coastal: false},
+    "Denmark": {civ: "Denmark", leader: "Harald Bluetooth", coastal: true},
+    "Egypt": {civ: "Egypt", leader: "Ramesses II", coastal: false},
+    "England": {civ: "England", leader: "Elizabeth", coastal: true},
+    "Ethiopia": {civ: "Ethiopia", leader: "Haile Selassie", coastal: false},
+    "Finland": {civ: "Finland", leader: "Mannerheim", coastal: false},
+    "France": {civ: "France", leader: "Napoleon", coastal: false},
+    "Franks": {civ: "Franks", leader: "Charlemagne", coastal: false},
+    "Gauls": {civ: "Gaul", leader: "Vercingetorix", coastal: false},
+    "Georgia": {civ: "Georgia", leader: "Tamar", coastal: false},
+    "Germany": {civ: "Germany", leader: "Bismarck", coastal: false},
+    "Golden Horde": {civ: "Golden Horde", leader: "Batu Khan", coastal: false},
+    "Goths": {civ: "Goths", leader: "Alaric I", coastal: false},
+    "Greece": {civ: "Greece", leader: "Pericles", coastal: false},
+    "Hittites": {civ: "Hittites", leader: "Muwatallis", coastal: false},
+    "Hungary": {civ: "Hungary", leader: "András II", coastal: false},
+    "Huns": {civ: "The Huns", leader: "Attila", coastal: false},
+    "Inca": {civ: "The Inca", leader: "Pachacuti", coastal: false},
+    "India": {civ: "India", leader: "Gandhi", coastal: false},
+    "Indonesia": {civ: "Indonesia", leader: "Gajah Mada", coastal: true},
+    "Ireland": {civ: "Ireland", leader: "Michael Collins", coastal: false},
+    "Iroquois": {civ: "The Iroquois", leader: "Hiawatha", coastal: false},
+    "Israel": {civ: "Israel", leader: "David", coastal: false},
+    "Italy": {civ: "Italy", leader: "Vittorio Emanuele III", coastal: false},
+    "Japan": {civ: "Japan", leader: "Oda Nobunaga", coastal: true},
+    "Jerusalem": {civ: "Jerusalem", leader: "Fulk V", coastal: false},
+    "Khmer": {civ: "Khmer", leader: "Suryavarman II", coastal: false},
+    "Kilwa": {civ: "Kilwa", leader: "Ali ibn al-Hassan Shirazi", coastal: true},
+    "Kongo": {civ: "Kongo", leader: "Mvemba a Nzinga", coastal: false},
+    "Korea": {civ: "Korea", leader: "Sejong", coastal: true},
+    "Lithuania": {civ: "Lithuania", leader: "Vytautas", coastal: false},
+    "Macedonia": {civ: "Macedonia", leader: "Alexander", coastal: false},
+    "Madagascar": {civ: "Madagascar", leader: "Ralambo", coastal: false},
+    "Manchuria": {civ: "Manchuria", leader: "Nurhaci", coastal: false},
+    "Maori": {civ: "Maori", leader: "Te Rauparaha", coastal: false},
+    "Maurya": {civ: "Maurya", leader: "Ashoka", coastal: false},
+    "Maya": {civ: "The Maya", leader: "Pacal", coastal: false},
+    "Mexico": {civ: "Mexico", leader: "Benito Juarez", coastal: false},
+    "Mongolia": {civ: "Mongolia", leader: "Genghis Khan", coastal: false},
+    "Moors": {civ: "Moors", leader: "Abd-ar-Rahman III", coastal: false},
+    "Morocco": {civ: "Morocco", leader: "Ahmad al-Mansur", coastal: false},
+    "Mysore": {civ: "Mysore", leader: "Hyder Ali", coastal: false},
+    "Nabatea": {civ: "Nabatea", leader: "Aretas III", coastal: false},
+    "Netherlands": {civ: "Netherlands", leader: "William", coastal: true},
+    "New Zealand": {civ: "New Zealand", leader: "Michael Joseph Savage", coastal: true},
+    "Normandy": {civ: "Normandy", leader: "William the Conqueror", coastal: false},
+    "Norway": {civ: "Norway", leader: "Harald Hardrada", coastal: true},
+    "Nubia": {civ: "Nubia", leader: "Amanitore", coastal: false},
+    "Oman": {civ: "Oman", leader: "Saif bin Sultan", coastal: true},
+    "Ottomans": {civ: "The Ottomans", leader: "Suleiman", coastal: false},
+    "Palmyra": {civ: "Palmyra", leader: "Zenobia", coastal: false},
+    "Papal State": {civ: "Papal State", leader: "Urban II", coastal: false},
+    "Persia": {civ: "Persia", leader: "Darius I", coastal: false},
+    "Phoenicia": {civ: "Phoenicia", leader: "Hiram", coastal: true},
+    "Philippines": {civ: "Phillipines", leader: "Emilio Aguinaldo", coastal: true},
+    "Poland": {civ: "Poland", leader: "Casimir III", coastal: false},
+    "Polynesia": {civ: "Polynesia", leader: "Kamehameha", coastal: true},
+    "Portugal": {civ: "Portugal", leader: "Maria I", coastal: true},
+    "Prussia": {civ: "Prussia", leader: "Frederick", coastal: false},
+    "Romania": {civ: "Romania", leader: "Carol I", coastal: false},
+    "Rome": {civ: "Rome", leader: "Augustus Caesar", coastal: false},
+    "Russia": {civ: "Russia", leader: "Catherine", coastal: false},
+    "Scotland": {civ: "Scotland", leader: "Robert the Bruce", coastal: false},
+    "Shoshone": {civ: "The Shoshone", leader: "Pocatello", coastal: false},
+    "Siam": {civ: "Siam", leader: "Ramkhamhaeng", coastal: false},
+    "Sioux": {civ: "Sioux", leader: "Sitting Bull", coastal: false},
+    "Songhai": {civ: "Songhai", leader: "Askia", coastal: false},
+    "Spain": {civ: "Spain", leader: "Isabella", coastal: true},
+    "Sumeria": {civ: "Sumeria", leader: "Gilgamesh", coastal: false},
+    "Sweden": {civ: "Sweden", leader: "Gustavus Adolphus", coastal: false},
+    "Switzerland": {civ: "Switzerland", leader: "Jonas Furrer", coastal: false},
+    "Tibet": {civ: "Tibet", leader: "Ngawang Lobsang Gyatso", coastal: false},
+    "Timurids": {civ: "Timurids", leader: "Timur", coastal: false},
+    "Tonga": {civ: "Tonga", leader: "'Aho'eitu", coastal: true},
+    "Turkey": {civ: "Turkey", leader: "Ataturk", coastal: false},
+    "U.A.E": {civ: "U.A.E", leader: "Sheikh Zayed", coastal: true},
+    "Ukraine": {civ: "Ukraine", leader: "Yaroslav I", coastal: false},
+    "Venice": {civ: "Venice", leader: "Enrico Dandolo", coastal: true},
+    "Vietnam": {civ: "Vietnam", leader: "Hai Ba Trung", coastal: false},
+    "Wales": {civ: "Wales", leader: "Owain Glyndwr", coastal: false},
+    "Yugoslavia": {civ: "Yugoslavia", leader: "Aleksandar I", coastal: false},
+    "Zimbabwe": {civ: "Zimbabwe", leader: "Nyatsimba Mutota", coastal: false},
+    "Zulu": {civ: "The Zulu", leader: "Shaka", coastal: false},
+
+    // Civ 6
+    "AbrahamLincoln": {leader: "Abraham Lincoln", civ: "America", coastal: false,},
+    "Alexander": {leader: "Alexander", civ: "Macedon", coastal: false,},
+    "Amanitore": {leader: "Amanitore", civ: "Nubia", coastal: false,},
+    "Ambiorix": {leader: "Ambiorix", civ: "Gaul", coastal: false,},
+    "BasilII": {leader: "Basil II", civ: "Byzantium", coastal: false,},
+    "BaTrieu": {leader: "Bà Triệu", civ: "Vietnam", coastal: false,},
+    "CatherineDeMediciBlackQueen": {leader: "Catherine de Medici (Black Queen)", civ: "France", coastal: false,},
+    "CatherineDeMediciMagnificence": {leader: "Catherine de Medici (Magnificence)", civ: "France", coastal: false,},
+    "Chandragupta": {leader: "Chandragupta", civ: "India", coastal: false,},
+    "CleopatraEgyptian": {leader: "Cleopatra (Egyptian)", civ: "Egypt", coastal: false,},
+    "CleopatraPtolemaic": {leader: "Cleopatra (Ptolemaic)", civ: "Egypt", coastal: false,},
+    "Cyrus": {leader: "Cyrus", civ: "Persia", coastal: false,},
+    "Dido": {leader: "Dido", civ: "Phoenicia", coastal: true,},
+    "Eleanor_England": {leader: "Eleanor of Aquitaine", civ: "England", coastal: true,},
+    "Eleanor_France": {leader: "Eleanor of Aquitaine", civ: "France", coastal: false,},
+    "ElizabethI": {leader: "Elizabeth I", civ: "England", coastal: true,},
+    "FrederickBarbarossa": {leader: "Frederick Barbarossa", civ: "Germany", coastal: false,},
+    "Gandhi": {leader: "Gandhi", civ: "India", coastal: false,},
+    "GenghisKhan": {leader: "Genghis Khan", civ: "Mongolia", coastal: false,},
+    "Gilgamesh": {leader: "Gilgamesh", civ: "Sumeria", coastal: false,},
+    "Gitarja": {leader: "Gitarja", civ: "Indonesia", coastal: true,},
+    "Gorgo": {leader: "Gorgo", civ: "Greece", coastal: false,},
+    "Hammurabi": {leader: "Hammurabi", civ: "Babylon", coastal: false,},
+    "HaraldHardradaKonge": {leader: "Harald Hardrada (Konge)", civ: "Norway", coastal: true,},
+    "HaraldHardradaVarangian": {leader: "Harald Hardrada (Varangian)", civ: "Norway", coastal: true,},
+    "HojoTokimune": {leader: "Hojo Tokimune", civ: "Japan", coastal: true,},
+    "Jadwiga": {leader: "Jadwiga", civ: "Poland", coastal: false,},
+    "JayavarmanVII": {leader: "Jayavarman VII", civ: "Khmer", coastal: false,},
+    "JoaoIII": {leader: "João III", civ: "Portugal", coastal: true,},
+    "JohnCurtin": {leader: "John Curtin", civ: "Australia", coastal: true,},
+    "JuliusCaesar": {leader: "Julius Caesar", civ: "Rome", coastal: false,},
+    "Kristina": {leader: "Kristina", civ: "Sweden", coastal: false,},
+    "KublaiKhan_China": {leader: "Kublai Khan", civ: "China", coastal: false,},
+    "KublaiKhan_Mongolia": {leader: "Kublai Khan", civ: "Mongolia", coastal: false,},
+    "Kupe": {leader: "Kupe", civ: "The Maori", coastal: true,},
+    "LadySixSky": {leader: "Lady Six Sky", civ: "Maya", coastal: false,},
+    "Lautaro": {leader: "Lautaro", civ: "Mapuche", coastal: false,},
+    "LudwigII": {leader: "Ludwig II", civ: "Germany", coastal: false,},
+    "MansaMusa": {leader: "Mansa Musa", civ: "Mali", coastal: false,},
+    "MatthiasCorvinus": {leader: "Matthias Corvinus", civ: "Hungary", coastal: false,},
+    "MenelikII": {leader: "Menelik II", civ: "Ethiopia", coastal: false,},
+    "Monetuzuma": {leader: "Montezuma", civ: "Aztec", coastal: false,},
+    "MvembaANzinga": {leader: "Mvemba a Nzinga", civ: "Kongo", coastal: false,},
+    "NaderShah": {leader: "Nader Shah", civ: "Persia", coastal: false,},
+    "NzingaMbande": {leader: "Nzinga Mbande", civ: "Kongo", coastal: false,},
+    "Pachacuti": {leader: "Pachacuti", civ: "The Inca", coastal: false,},
+    "PedroII": {leader: "Pedro II", civ: "Brazil", coastal: false,},
+    "Pericles": {leader: "Pericles", civ: "Greece", coastal: false,},
+    "Peter": {leader: "Peter", civ: "Russia", coastal: false,},
+    "PhilipII": {leader: "Philip II", civ: "Spain", coastal: false,},
+    "Poundmaker": {leader: "Poundmaker", civ: "Cree", coastal: false,},
+    "QinShiHuangMandate": {leader: "Qin Shi Huang (Mandate of Heaven)", civ: "China", coastal: false,},
+    "QinShiHuangUnifier": {leader: "Qin Shi Huang (Unifier)", civ: "China", coastal: false,},
+    "RamsesII": {leader: "Ramses II", civ: "Egypt", coastal: false,},
+    "RobertTheBruce": {leader: "Robert the Bruce", civ: "Scotland", coastal: false,},
+    "SaladinSultan": {leader: "Saladin (Sultan)", civ: "Arabia", coastal: false,},
+    "SaladinVizier": {leader: "Saladin (Vizier)", civ: "Arabia", coastal: false,},
+    "Sejong": {leader: "Sejong", civ: "Korea", coastal: false,},
+    "Seondeok": {leader: "Seondeok", civ: "Korea", coastal: false,},
+    "Shaka": {leader: "Shaka", civ: "Zulu", coastal: false,},
+    "SimonBolivar": {leader: "Simón Bolívar", civ: "Gran Colombia", coastal: false,},
+    "SuleimanKanuni": {leader: "Suleiman (Kanuni)", civ: "The Ottomans", coastal: false,},
+    "SuleimanMuhtesem": {leader: "Suleiman (Muhtesem)", civ: "The Ottomans", coastal: false,},
+    "SundiataKeita": {leader: "Sundiata Keita", civ: "Mali", coastal: false,},
+    "Tamar": {leader: "Tamar", civ: "Georgia", coastal: false,},
+    "TeddyBullMoose": {leader: "Teddy Roosevelt (Bull Moose)", civ: "America", coastal: false,},
+    "TeddyRoughRider": {leader: "Teddy Roosevelt (Rough Rider)", civ: "America", coastal: false,},
+    "Theodora": {leader: "Theodora", civ: "Byzantium", coastal: false,},
+    "Tokugawa": {leader: "Tokugawa", civ: "Japan", coastal: true,},
+    "Tomyris": {leader: "Tomyris", civ: "Scythia", coastal: false,},
+    "Trajan": {leader: "Trajan", civ: "Rome", coastal: false,},
+    "VictoriaEmpire": {leader: "Victoria (Age of Empire)", civ: "England", coastal: false,},
+    "VictoriaSteam": {leader: "Victoria (Age of Steam)", civ: "England", coastal: false,},
+    "WilfredLaurier": {leader: "Wilfred Laurier", civ: "Canada", coastal: false,},
+    "Wilhelmina": {leader: "Wilhelmina", civ: "The Netherlands", coastal: true,},
+    "WuZetian": {leader: "Wu Zetian", civ: "China", coastal: false,},
+    "Yongle": {leader: "Yongle", civ: "China", coastal: false,},
+} 

--- a/src/Civs/Expansions.ts
+++ b/src/Civs/Expansions.ts
@@ -31,6 +31,10 @@ export function expansionsInGame(game: CivGame) {
     return Expansions.filter((x) => ExpansionMetadata[x].game === game);
 }
 
+export function gameOfExpansion(expansion: Expansion) {
+    return ExpansionMetadata[expansion].game;
+}
+
 export function displayName(expansion: Expansion) {
     return ExpansionMetadata[expansion].displayName;
 }

--- a/src/Civs/SelectCivIds.ts
+++ b/src/Civs/SelectCivIds.ts
@@ -1,0 +1,9 @@
+﻿import { Expansion } from "./Expansions";
+import {CivId, Civs} from "./Civs";
+
+export function selectCivIds(expansions: Expansion[], excludedCivs: CivId[]): CivId[] {
+    return Array.from(new Set(expansions))
+        .map((expansion) => Civs[expansion])
+        .reduce((prev: CivId[], current: CivId[]) => current.concat(prev), [])
+        .filter((x) => !excludedCivs.some(y => x === y));
+}

--- a/src/Civs/SelectCivs.ts
+++ b/src/Civs/SelectCivs.ts
@@ -1,9 +1,0 @@
-﻿import { Expansion } from "./Expansions";
-import {Civ, Civs, civsEqual} from "./Civs";
-
-export function selectCivs(expansions: Expansion[], excludedCivs: Civ[]): Civ[] {
-    return Array.from(new Set(expansions))
-        .map((expansion) => Civs[expansion])
-        .reduce((prev: Civ[], current: Civ[]) => current.concat(prev), [])
-        .filter((x) => !excludedCivs.some(y => civsEqual(x, y)));
-}

--- a/src/Civs/__tests__/SelectCivIds.test.ts
+++ b/src/Civs/__tests__/SelectCivIds.test.ts
@@ -1,7 +1,7 @@
 import { selectCivIds } from "../SelectCivIds";
-import { Civs } from "../Civs";
+import {CivId, Civs} from "../Civs";
 
-describe("selectCivs", () => {
+describe("selectCivIds", () => {
     it("should return no civs if no expansions are given", () => {
         const civs = selectCivIds([], []);
         expect(civs).toHaveLength(0);
@@ -14,7 +14,7 @@ describe("selectCivs", () => {
 
     it("should return the civs of multiple expansions when specified", () => {
         const civs = selectCivIds(["civ5-vanilla", "lekmod"], []);
-        expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"].concat(Civs["lekmod"]));
+        expect(civs).toIncludeSameMembers((Civs["civ5-vanilla"] as CivId[]).concat(Civs["lekmod"]));
     });
 
     it("should not include banned civs", () => {

--- a/src/Civs/__tests__/SelectCivs.test.ts
+++ b/src/Civs/__tests__/SelectCivs.test.ts
@@ -1,24 +1,24 @@
-import { selectCivs } from "../SelectCivs";
+import { selectCivIds } from "../SelectCivIds";
 import { Civs } from "../Civs";
 
 describe("selectCivs", () => {
     it("should return no civs if no expansions are given", () => {
-        const civs = selectCivs([], []);
+        const civs = selectCivIds([], []);
         expect(civs).toHaveLength(0);
     });
 
     it("should return the civs of one expansion when specified", () => {
-        const civs = selectCivs(["civ5-vanilla"], []);
+        const civs = selectCivIds(["civ5-vanilla"], []);
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"]);
     });
 
     it("should return the civs of multiple expansions when specified", () => {
-        const civs = selectCivs(["civ5-vanilla", "lekmod"], []);
+        const civs = selectCivIds(["civ5-vanilla", "lekmod"], []);
         expect(civs).toIncludeSameMembers(Civs["civ5-vanilla"].concat(Civs["lekmod"]));
     });
 
     it("should not include banned civs", () => {
-        const civs = selectCivs(["civ5-vanilla"], ["Russia"]);
+        const civs = selectCivIds(["civ5-vanilla"], ["Russia"]);
         expect(civs).not.toInclude("Russia");
     });
 });

--- a/src/Commands/Ban/Autocomplete.ts
+++ b/src/Commands/Ban/Autocomplete.ts
@@ -1,7 +1,8 @@
 import { AutocompleteInteraction } from "discord.js";
 import { loadUserData } from "../../UserDataStore";
-import { selectCivs } from "../../Civs/SelectCivs";
-import { Civ, renderCiv } from "../../Civs/Civs";
+import { selectCivIds } from "../../Civs/SelectCivIds";
+import {CivId, getCiv, renderCiv} from "../../Civs/Civs";
+import {CivGame} from "../../Civs/CivGames";
 
 export async function banCommandAutocomplete(interaction: AutocompleteInteraction) {
     const queryString = interaction.options.getFocused();
@@ -12,7 +13,8 @@ export async function banCommandAutocomplete(interaction: AutocompleteInteractio
     await interaction.respond(
         autocompleteOptions(
             queryString,
-            selectCivs(userSettings.defaultDraftSettings.expansions ?? [], userSettings.bannedCivs),
+            selectCivIds(userSettings.defaultDraftSettings.expansions ?? [], userSettings.bannedCivs),
+            userData.game
         ),
     );
 }
@@ -23,12 +25,12 @@ export async function unbanCommandAutocomplete(interaction: AutocompleteInteract
     const userData = await loadUserData(interaction.guildId!);
     const userSettings = userData.userSettings[userData.game];
 
-    await interaction.respond(autocompleteOptions(queryString, userSettings.bannedCivs));
+    await interaction.respond(autocompleteOptions(queryString, userSettings.bannedCivs, userData.game));
 }
 
-function autocompleteOptions(queryString: string, civs: Civ[]) {
+function autocompleteOptions(queryString: string, civs: CivId[], game: CivGame) {
     return civs
-        .map(renderCiv)
+        .map(x => renderCiv(getCiv(x), game))
         .filter((x) => x.includes(queryString))
         .slice(0, 25)
         .map((choice) => ({ name: choice, value: choice }));

--- a/src/Commands/Ban/Ban.ts
+++ b/src/Commands/Ban/Ban.ts
@@ -1,15 +1,15 @@
 import { UserData } from "../../UserData/UserData";
-import { Civ, civsEqual } from "../../Civs/Civs";
+import {CivId} from "../../Civs/Civs";
 import { saveUserData } from "../../UserDataStore";
 
-export async function banCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
+export async function banCivs(serverId: string, userData: UserData, civsToBan: CivId[]) {
     userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.concat(civsToBan);
     await saveUserData(serverId, userData);
 }
 
-export async function unbanCivs(serverId: string, userData: UserData, civsToBan: Civ[]) {
+export async function unbanCivs(serverId: string, userData: UserData, civsToBan: CivId[]) {
     userData.userSettings[userData.game].bannedCivs = userData.userSettings[userData.game].bannedCivs.filter(
-        (civ) => !civsToBan.some((x) => civsEqual(civ, x)),
+        (civ) => !civsToBan.some((x) => civ === x),
     );
     await saveUserData(serverId, userData);
 }

--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,8 +1,9 @@
 import { loadUserData } from "../../UserDataStore";
-import { Civ, renderCiv } from "../../Civs/Civs";
+import {Civ, CivId, getCiv, renderCiv} from "../../Civs/Civs";
 import { ChatInputCommandInteraction } from "discord.js";
 import { banCivs } from "./Ban";
-import { selectCivs } from "../../Civs/SelectCivs";
+import { selectCivIds } from "../../Civs/SelectCivIds";
+import {CivGame} from "../../Civs/CivGames";
 
 export async function banCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -11,10 +12,10 @@ export async function banCommand(interaction: ChatInputCommandInteraction) {
     const userData = await loadUserData(serverId);
     const userSettings = userData.userSettings[userData.game];
 
-    const allMatchedCivs = selectCivs(
+    const allMatchedCivs = selectCivIds(
         userSettings.defaultDraftSettings.expansions ?? [],
         userSettings.bannedCivs,
-    ).filter((civ) => renderCiv(civ).toLowerCase().includes(searchString));
+    ).filter((civ) => renderCiv(getCiv(civ), userData.game).toLowerCase().includes(searchString));
 
     if (allMatchedCivs.length == 0) {
         await interaction.reply(`"${searchString}" didn't match any civs currently included in your draft.`);
@@ -28,11 +29,11 @@ export async function banCommand(interaction: ChatInputCommandInteraction) {
     } else {
         const chosenCiv = allMatchedCivs[0];
         await banCivs(serverId, userData, [chosenCiv]);
-        await interaction.reply(banMessage(chosenCiv));
+        await interaction.reply(banMessage(chosenCiv, userData.game));
         return;
     }
 }
 
-function banMessage(bannedCiv: Civ) {
-    return `\`${renderCiv(bannedCiv)}\` has been banned. It will no longer appear in your drafts.`;
+function banMessage(bannedCiv: CivId, civGame: CivGame) {
+    return `\`${renderCiv(getCiv(bannedCiv), civGame)}\` has been banned. It will no longer appear in your drafts.`;
 }

--- a/src/Commands/Ban/UnbanCommand.ts
+++ b/src/Commands/Ban/UnbanCommand.ts
@@ -1,7 +1,8 @@
 import { loadUserData } from "../../UserDataStore";
 import { ChatInputCommandInteraction } from "discord.js";
-import { Civ, renderCiv } from "../../Civs/Civs";
+import {Civ, CivId, getCiv, renderCiv} from "../../Civs/Civs";
 import { unbanCivs } from "./Ban";
+import {CivGame} from "../../Civs/CivGames";
 
 export async function unbanCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -9,8 +10,8 @@ export async function unbanCommand(interaction: ChatInputCommandInteraction) {
     const searchString = interaction.options.getString("civ")!.toLowerCase();
     const userData = await loadUserData(serverId);
 
-    const allMatchedCivs = userData.userSettings[userData.game].bannedCivs.filter((civ) =>
-        renderCiv(civ).toLowerCase().includes(searchString),
+    const allMatchedCivs = userData.userSettings[userData.game].bannedCivs.filter((civId) =>
+        renderCiv(getCiv(civId), userData.game).toLowerCase().includes(searchString),
     );
 
     if (allMatchedCivs.length == 0) {
@@ -25,11 +26,11 @@ export async function unbanCommand(interaction: ChatInputCommandInteraction) {
     } else {
         const chosenCiv = allMatchedCivs[0];
         await unbanCivs(serverId, userData, [chosenCiv]);
-        await interaction.reply(unbanMessage(chosenCiv));
+        await interaction.reply(unbanMessage(chosenCiv, userData.game));
         return;
     }
 }
 
-function unbanMessage(unbannedCiv: Civ) {
-    return `\`${renderCiv(unbannedCiv)}\` has been unbanned. It will once again appear in your drafts.`;
+function unbanMessage(unbannedCiv: CivId, civGame: CivGame) {
+    return `\`${renderCiv(getCiv(unbannedCiv), civGame)}\` has been unbanned. It will once again appear in your drafts.`;
 }

--- a/src/Commands/Ban/__tests__/BanCommand.test.ts
+++ b/src/Commands/Ban/__tests__/BanCommand.test.ts
@@ -56,7 +56,7 @@ describe("BanCommand", () => {
             const userData = await getTestUserData();
 
             expect(interaction.output).not.toBeEmpty();
-            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Peter", civ: "Russia"}]);
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual(["Peter"]);
         });
 
         it("should ban based on leader name", async () => {
@@ -67,7 +67,7 @@ describe("BanCommand", () => {
             const userData = await getTestUserData();
 
             expect(interaction.output).not.toBeEmpty();
-            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Trajan", civ: "Rome"}]);
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual(["Trajan"]);
         });
 
         it("should not ban the civ if the civ is already banned", async () => {
@@ -79,7 +79,7 @@ describe("BanCommand", () => {
             const userData = await getTestUserData();
 
             expect(interaction.output).not.toBeEmpty();
-            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual([{leader: "Trajan", civ: "Rome"}]);
+            expect(userData.userSettings["Civ 6"].bannedCivs).toEqual(["Trajan"]);
         });
 
         it("should not ban the civ if it doesn't exist", async () => {

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -1,8 +1,9 @@
-import { displayName } from "../../Civs/Expansions";
-import { UserData } from "../../UserData/UserData";
-import { Civ, renderCiv } from "../../Civs/Civs";
-import { ChatInputCommandInteraction } from "discord.js";
-import { loadUserData } from "../../UserDataStore";
+import {displayName} from "../../Civs/Expansions";
+import {UserData} from "../../UserData/UserData";
+import {CivId, getCiv, renderCiv} from "../../Civs/Civs";
+import {ChatInputCommandInteraction} from "discord.js";
+import {loadUserData} from "../../UserDataStore";
+import {CivGame} from "../../Civs/CivGames";
 
 export async function showConfigCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -21,7 +22,7 @@ CivBot is drafting for **${userData.game}**.
 
 Enabled expansions: \`\`\`${activeSettings.defaultDraftSettings?.expansions?.map(displayName).join("\n")}\`\`\`
 ${anyCustomCivs ? customCivsLine(activeSettings.customCivs) : ""}
-${anyBannedCivs ? bannedCivsLine(activeSettings.bannedCivs) : ""}`.trim();
+${anyBannedCivs ? bannedCivsLine(activeSettings.bannedCivs, userData.game) : ""}`.trim();
 }
 
 function customCivsLine(customCivs: string[]) {
@@ -32,6 +33,6 @@ function customCivsLine(customCivs: string[]) {
     }
 }
 
-function bannedCivsLine(bannedCivs: Civ[]) {
-    return `Banned civs:\`\`\`\n${bannedCivs.sort().map(renderCiv).join("\n")}\`\`\``;
+function bannedCivsLine(bannedCivs: CivId[], game: CivGame) {
+    return `Banned civs:\`\`\`\n${bannedCivs.sort().map(x => renderCiv(getCiv(x), game)).join("\n")}\`\`\``;
 }

--- a/src/Commands/Draft/Draft.ts
+++ b/src/Commands/Draft/Draft.ts
@@ -1,9 +1,9 @@
-import { Draft, DraftError } from "./DraftTypes";
+import {Draft, DraftedCiv, DraftError} from "./DraftTypes";
 import * as shuffle from "shuffle-array";
 import { Result } from "../../Functional/Result";
-import { Civ } from "../../Civs/Civs";
+import {Civ, CivId} from "../../Civs/Civs";
 
-function assignCivs(players: string[], civsPerPlayer: number, civs: Civ[]): Draft {
+function assignCivs(players: string[], civsPerPlayer: number, civs: DraftedCiv[]): Draft {
     shuffle(civs);
 
     return players.map((player, index) => {
@@ -11,7 +11,7 @@ function assignCivs(players: string[], civsPerPlayer: number, civs: Civ[]): Draf
     });
 }
 
-export function draft(players: string[], civsPerPlayer: number, civs: Civ[]): Result<Draft, DraftError> {
+export function draft(players: string[], civsPerPlayer: number, civs: DraftedCiv[]): Result<Draft, DraftError> {
     if (players.length == 0) {
         return { isError: true, error: "no-players" };
     }

--- a/src/Commands/Draft/Draft.ts
+++ b/src/Commands/Draft/Draft.ts
@@ -1,26 +1,53 @@
 import {Draft, DraftedCiv, DraftError} from "./DraftTypes";
 import * as shuffle from "shuffle-array";
-import { Result } from "../../Functional/Result";
-import {Civ, CivId} from "../../Civs/Civs";
+import {Result} from "../../Functional/Result";
+import {getCiv} from "../../Civs/Civs";
 
 function assignCivs(players: string[], civsPerPlayer: number, civs: DraftedCiv[]): Draft {
     shuffle(civs);
 
     return players.map((player, index) => {
-        return { player: player, civs: civs.slice(index * civsPerPlayer, (index + 1) * civsPerPlayer) };
+        return {player: player, civs: civs.slice(index * civsPerPlayer, (index + 1) * civsPerPlayer)};
     });
+}
+
+export function draftWithGuaranteedCoastal(players: string[], civsPerPlayer: number, civs: DraftedCiv[]): Result<Draft, DraftError> {
+    const coastalCivs = civs.filter(x => !x.custom && getCiv(x.id).coastal);
+
+    if (coastalCivs.length < players.length) {
+        return {isError: true, error: "not-enough-coastal-civs"}
+    }
+
+    shuffle(coastalCivs);
+    const chosenCoastalCivs = coastalCivs.slice(0, players.length);
+
+    const draftResult = draft(players, civsPerPlayer - 1, civs.filter(x => !chosenCoastalCivs.includes(x)));
+
+    if (!draftResult.isError) {
+        const draftEntriesWithCoastal = draftResult.value.map((draftEntry, i) => ({
+            ...draftEntry,
+            civs: draftEntry.civs.concat([chosenCoastalCivs[i]])
+        }))
+
+        return {
+            isError: false,
+            value: draftEntriesWithCoastal
+        }
+    }
+
+    return draftResult;
 }
 
 export function draft(players: string[], civsPerPlayer: number, civs: DraftedCiv[]): Result<Draft, DraftError> {
     if (players.length == 0) {
-        return { isError: true, error: "no-players" };
+        return {isError: true, error: "no-players"};
     }
 
     if (players.length * civsPerPlayer > civs.length) {
-        return { isError: true, error: "not-enough-civs" };
+        return {isError: true, error: "not-enough-civs"};
     }
 
     let draft = assignCivs(players, civsPerPlayer, civs);
 
-    return { isError: false, value: draft };
+    return {isError: false, value: draft};
 }

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -1,5 +1,5 @@
 import {Expansion} from "../../Civs/Expansions";
-import {draft} from "./Draft";
+import {draft, draftWithGuaranteedCoastal} from "./Draft";
 import {selectCivIds} from "../../Civs/SelectCivIds";
 import {UserSettings} from "../../UserData/UserSettings";
 import {generateDraftMessage} from "./DraftCommandMessages";
@@ -14,6 +14,7 @@ export type DraftArguments = {
     numberOfAi: number;
     numberOfCivs: number;
     expansions: Expansion[];
+    guaranteeCoastal: boolean;
 };
 
 export async function draftCommand(interaction: ChatInputCommandInteraction) {
@@ -31,7 +32,10 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
 
     const civsIncludingCustom = civs.concat(userSettings.customCivs.map(x => ({custom: true, name: x})));
 
-    const draftResult = draft(players, draftArgs.numberOfCivs, civsIncludingCustom);
+    const draftResult = draftArgs.guaranteeCoastal ? 
+        draftWithGuaranteedCoastal(players, draftArgs.numberOfCivs, civsIncludingCustom) : 
+        draft(players, draftArgs.numberOfCivs, civsIncludingCustom);
+    
     let draftMessage = generateDraftMessage(
         userData.game,
         draftArgs.expansions,
@@ -114,6 +118,7 @@ function fillDefaultArguments(partialArgs: Partial<DraftArguments>, userSettings
         numberOfAi: partialArgs.numberOfAi ?? defaultArgs.numberOfAi ?? 0,
         numberOfCivs: partialArgs.numberOfCivs ?? defaultArgs.numberOfCivs ?? 3,
         expansions: partialArgs.expansions ?? defaultArgs.expansions ?? ["civ5-vanilla"],
+        guaranteeCoastal: partialArgs.guaranteeCoastal ?? false,
     };
 }
 

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -133,9 +133,11 @@ function generateAiPlayers(numberOfAiPlayers: number) {
 function extractDraftArguments(interaction: ChatInputCommandInteraction): Partial<DraftArguments> {
     const ai = interaction.options.getInteger("ai") ?? undefined;
     const civs = interaction.options.getInteger("civs") ?? undefined;
+    const guaranteeCoastal = interaction.options.getBoolean("guarantee-coastal") ?? undefined;
 
     return {
         numberOfCivs: civs,
         numberOfAi: ai,
+        guaranteeCoastal: guaranteeCoastal
     };
 }

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -1,12 +1,14 @@
-import { Expansion } from "../../Civs/Expansions";
-import { draft } from "./Draft";
-import { selectCivs } from "../../Civs/SelectCivs";
-import { UserSettings } from "../../UserData/UserSettings";
-import { generateDraftMessage } from "./DraftCommandMessages";
-import { ChatInputCommandInteraction, CommandInteraction, Message } from "discord.js";
-import { getVoiceChannelMembers } from "../../Discord/VoiceChannels";
-import { loadUserData } from "../../UserDataStore";
-import { isFeatureEnabled } from "../../UserData/FeatureFlags";
+import {Expansion} from "../../Civs/Expansions";
+import {draft} from "./Draft";
+import {selectCivIds} from "../../Civs/SelectCivIds";
+import {UserSettings} from "../../UserData/UserSettings";
+import {generateDraftMessage} from "./DraftCommandMessages";
+import {ChatInputCommandInteraction, CommandInteraction, Message} from "discord.js";
+import {getVoiceChannelMembers} from "../../Discord/VoiceChannels";
+import {loadUserData} from "../../UserDataStore";
+import {isFeatureEnabled} from "../../UserData/FeatureFlags";
+import {Civ, CivId, getCiv} from "../../Civs/Civs";
+import {DraftedCiv} from "./DraftTypes";
 
 export type DraftArguments = {
     numberOfAi: number;
@@ -24,9 +26,12 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
     const draftArgs = fillDefaultArguments(providedArgs, userSettings);
 
     const players = (await getVoiceChannelMembers(interaction)).concat(generateAiPlayers(draftArgs.numberOfAi));
-    const civs = selectCivs(draftArgs.expansions, userSettings.bannedCivs).concat(userSettings.customCivs);
+    const civs: DraftedCiv[] = selectCivIds(draftArgs.expansions, userSettings.bannedCivs)
+        .map(x => ({custom: false, id: x}));
 
-    const draftResult = draft(players, draftArgs.numberOfCivs, civs);
+    const civsIncludingCustom = civs.concat(userSettings.customCivs.map(x => ({custom: true, name: x})));
+
+    const draftResult = draft(players, draftArgs.numberOfCivs, civsIncludingCustom);
     let draftMessage = generateDraftMessage(
         userData.game,
         draftArgs.expansions,

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -40,6 +40,7 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
         userData.game,
         draftArgs.expansions,
         userSettings.customCivs.length,
+        draftArgs.guaranteeCoastal,
         draftResult,
     );
 
@@ -58,7 +59,10 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
                 userData.game,
                 draftArgs.expansions,
                 userSettings.customCivs.length,
-                draft(players, draftArgs.numberOfCivs, civs),
+                draftArgs.guaranteeCoastal,
+                draftArgs.guaranteeCoastal ?
+                    draftWithGuaranteedCoastal(players, draftArgs.numberOfCivs, civsIncludingCustom) :
+                    draft(players, draftArgs.numberOfCivs, civsIncludingCustom)
             );
         });
     }

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -17,10 +17,12 @@ export function generateDraftMessage(
     };
 
     if (draftResult.isError) {
-        if (draftResult.error == "no-players") {
+        if (draftResult.error === "no-players") {
             sendMessage(Messages.NoPlayers);
-        } else if (draftResult.error == "not-enough-civs") {
+        } else if (draftResult.error === "not-enough-civs") {
             sendMessage(Messages.NotEnoughCivs);
+        } else if (draftResult.error === "not-enough-coastal-civs") {
+            sendMessage(Messages.NotEnoughCoastalCivs)
         }
     } else {
         if (renderDraft(draftResult.value, game) === "") {

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -9,6 +9,7 @@ export function generateDraftMessage(
     game: CivGame,
     expansionsUsed: Expansion[],
     numberOfCustomCivs: number,
+    guaranteeCoastal: boolean,
     draftResult: Result<Draft, DraftError>
 ) {
     let message = "";
@@ -28,7 +29,7 @@ export function generateDraftMessage(
         if (renderDraft(draftResult.value, game) === "") {
             sendMessage(Messages.NoPlayers);
         } else {
-            sendMessage(renderDraftDescription(game, expansionsUsed, numberOfCustomCivs));
+            sendMessage(renderDraftDescription(game, expansionsUsed, numberOfCustomCivs, guaranteeCoastal));
             sendMessage(renderDraft(draftResult.value, game));
         }
     }
@@ -36,10 +37,11 @@ export function generateDraftMessage(
     return message;
 }
 
-function renderDraftDescription(game: "Civ 5" | "Civ 6", expansionsUsed: Expansion[], numberOfCustomCivs: number) {
+function renderDraftDescription(game: "Civ 5" | "Civ 6", expansionsUsed: Expansion[], numberOfCustomCivs: number, guaranteeCoastal: boolean) {
     const expansions = expansionsUsed.map((cg) => `\`${displayName(cg)}\``).join(", ");
     const customCivs = numberOfCustomCivs > 0 ? ` and ${numberOfCustomCivs} custom civs` : "";
-    return `Drafting for ${game} with ${expansions}${customCivs}`;
+    const guaranteeCoastalText = guaranteeCoastal ? " with guaranteed coastal civs" : "";
+    return `Drafting for ${game} with ${expansions}${customCivs}${guaranteeCoastalText}`;
 }
 
 function renderDraft(draft: Draft, game: CivGame) {

--- a/src/Commands/Draft/DraftCommandMessages.ts
+++ b/src/Commands/Draft/DraftCommandMessages.ts
@@ -2,7 +2,7 @@
 import { Draft, DraftEntry, DraftError } from "./DraftTypes";
 import { displayName, Expansion } from "../../Civs/Expansions";
 import { Result } from "../../Functional/Result";
-import { renderCivShort } from "../../Civs/Civs";
+import {getCiv, renderCivShort} from "../../Civs/Civs";
 import { CivGame } from "../../Civs/CivGames";
 
 export function generateDraftMessage(
@@ -23,11 +23,11 @@ export function generateDraftMessage(
             sendMessage(Messages.NotEnoughCivs);
         }
     } else {
-        if (renderDraft(draftResult.value) === "") {
+        if (renderDraft(draftResult.value, game) === "") {
             sendMessage(Messages.NoPlayers);
         } else {
             sendMessage(renderDraftDescription(game, expansionsUsed, numberOfCustomCivs));
-            sendMessage(renderDraft(draftResult.value));
+            sendMessage(renderDraft(draftResult.value, game));
         }
     }
 
@@ -40,10 +40,17 @@ function renderDraftDescription(game: "Civ 5" | "Civ 6", expansionsUsed: Expansi
     return `Drafting for ${game} with ${expansions}${customCivs}`;
 }
 
-function renderDraft(draft: Draft) {
-    return `\`\`\`${draft.map(renderDraftEntry).join("\n")}\`\`\``;
+function renderDraft(draft: Draft, game: CivGame) {
+    return `\`\`\`${draft.map(x => renderDraftEntry(x, game)).join("\n")}\`\`\``;
 }
 
-function renderDraftEntry(draftEntry: DraftEntry): string {
-    return `${`${draftEntry.player}`.padEnd(20, " ")} ${draftEntry.civs.map(renderCivShort).join(" / ")}`;
+function renderDraftEntry(draftEntry: DraftEntry, game: CivGame): string {
+    return `${`${draftEntry.player}`.padEnd(20, " ")} ${draftEntry.civs.map(x => {
+        if (x.custom) {
+            return x.name
+        }
+        else {
+            return renderCivShort(getCiv(x.id), game)
+        }
+    }).join(" / ")}`;
 }

--- a/src/Commands/Draft/DraftTypes.ts
+++ b/src/Commands/Draft/DraftTypes.ts
@@ -9,4 +9,4 @@ export type DraftEntry = {
     civs: DraftedCiv[];
 };
 
-export type DraftError = "no-players" | "not-enough-civs";
+export type DraftError = "no-players" | "not-enough-civs" | "not-enough-coastal-civs";

--- a/src/Commands/Draft/DraftTypes.ts
+++ b/src/Commands/Draft/DraftTypes.ts
@@ -1,10 +1,12 @@
-﻿import { Civ } from "../../Civs/Civs";
+﻿import {CivId} from "../../Civs/Civs";
 
 export type Draft = DraftEntry[];
 
+export type DraftedCiv = { custom: false, id: CivId } | { custom: true, name: string };
+
 export type DraftEntry = {
     player: string;
-    civs: Civ[];
+    civs: DraftedCiv[];
 };
 
 export type DraftError = "no-players" | "not-enough-civs";

--- a/src/Commands/Draft/__tests__/Draft.test.ts
+++ b/src/Commands/Draft/__tests__/Draft.test.ts
@@ -1,8 +1,9 @@
 ﻿import { extractErrorAndAssertIsError, extractResultAndAssertIsNotError } from "../../../TestUtils";
 import { draft } from "../Draft";
+import { DraftedCiv } from "../DraftTypes";
 
 describe("draft", () => {
-    const civs = generateArray(20);
+    const civs: DraftedCiv[] = generateArray(20).map(toDraftedCiv);
 
     it("should succeed under normal circumstances", async () => {
         const draftResultOrError = draft(generateArray(3), 3, civs);
@@ -42,4 +43,8 @@ describe("draft", () => {
 
 function generateArray(count: number): string[] {
     return Array.from(Array(count)).map((_, i) => `item${i}`);
+}
+
+function toDraftedCiv(name: string): DraftedCiv { 
+    return {custom: true, name: name}
 }

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -4,6 +4,7 @@ const Messages = {
         "Draft failed - not enough civs to assign to the players. Either add more expansions to your draft or decrease the number of civs per player.",
     GenericError: "Uh oh, something's gone wrong. It's probably Jack's fault.",
     Wowser: "Wowser!",
+    NotEnoughCoastalCivs: "Draft failed - there aren't enough coastal civs to guarantee each player will get one. Try drafting without `guaranteeCoastal`.",
 };
 
 export default Messages;

--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -4,7 +4,7 @@ const Messages = {
         "Draft failed - not enough civs to assign to the players. Either add more expansions to your draft or decrease the number of civs per player.",
     GenericError: "Uh oh, something's gone wrong. It's probably Jack's fault.",
     Wowser: "Wowser!",
-    NotEnoughCoastalCivs: "Draft failed - there aren't enough coastal civs to guarantee each player will get one. Try drafting without `guaranteeCoastal`.",
+    NotEnoughCoastalCivs: "Draft failed - there aren't enough coastal civs to guarantee each player will get one. Try drafting without `guarantee-coastal`.",
 };
 
 export default Messages;

--- a/src/SlashCommands/SlashCommands.ts
+++ b/src/SlashCommands/SlashCommands.ts
@@ -17,6 +17,12 @@ export function getCommands(game: CivGame) {
                 name: "civs",
                 description: "Number of civs to draft for each player (Default is 3)",
             },
+            {
+                type: ApplicationCommandOptionType.Boolean,
+                name: "guarantee-coastal",
+                description: "Ensure that each player receives at least one civ with a coastal bias",
+                required: false,
+            }
         ],
     };
 

--- a/src/UserData/UserSettings.ts
+++ b/src/UserData/UserSettings.ts
@@ -1,8 +1,8 @@
 import { DraftArguments } from "../Commands/Draft/DraftCommand";
-import {Civ} from "../Civs/Civs";
+import {Civ, CivId} from "../Civs/Civs";
 
 export type UserSettings = {
     defaultDraftSettings: Partial<DraftArguments>;
     customCivs: string[];
-    bannedCivs: Civ[];
+    bannedCivs: CivId[];
 };


### PR DESCRIPTION
Added the new draft option `guarantee-coastal`, which means each player is guaranteed to receive at least one coastal civ.

To do so, restructured the civ data to allow metadata for individual civs, while dealing with string CivIds in save data.