### PR TITLE
Bring back wowser and scrap the reroll feature completely

### DIFF
--- a/src/Commands/Ban/BanCommand.ts
+++ b/src/Commands/Ban/BanCommand.ts
@@ -1,9 +1,10 @@
 import { loadUserData } from "../../UserDataStore";
-import {Civ, CivId, getCiv, renderCiv} from "../../Civs/Civs";
+import {CivId, getCiv, renderCiv} from "../../Civs/Civs";
 import { ChatInputCommandInteraction } from "discord.js";
 import { banCivs } from "./Ban";
 import { selectCivIds } from "../../Civs/SelectCivIds";
 import {CivGame} from "../../Civs/CivGames";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export async function banCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -18,18 +19,18 @@ export async function banCommand(interaction: ChatInputCommandInteraction) {
     ).filter((civ) => renderCiv(getCiv(civ), userData.game).toLowerCase().includes(searchString));
 
     if (allMatchedCivs.length == 0) {
-        await interaction.reply(`"${searchString}" didn't match any civs currently included in your draft.`);
+        await civBotReply(interaction, `"${searchString}" didn't match any civs currently included in your draft.`);
         return;
     }
     if (allMatchedCivs.length > 1) {
-        await interaction.reply(
+        await civBotReply(interaction, 
             `"${searchString}" matches ${allMatchedCivs.length} civs currently included in your draft. Use the autocomplete to find the specific leader/civ you want to ban.`,
         );
         return;
     } else {
         const chosenCiv = allMatchedCivs[0];
         await banCivs(serverId, userData, [chosenCiv]);
-        await interaction.reply(banMessage(chosenCiv, userData.game));
+        await civBotReply(interaction, banMessage(chosenCiv, userData.game));
         return;
     }
 }

--- a/src/Commands/Ban/UnbanCommand.ts
+++ b/src/Commands/Ban/UnbanCommand.ts
@@ -3,6 +3,7 @@ import { ChatInputCommandInteraction } from "discord.js";
 import {Civ, CivId, getCiv, renderCiv} from "../../Civs/Civs";
 import { unbanCivs } from "./Ban";
 import {CivGame} from "../../Civs/CivGames";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export async function unbanCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -15,18 +16,18 @@ export async function unbanCommand(interaction: ChatInputCommandInteraction) {
     );
 
     if (allMatchedCivs.length == 0) {
-        await interaction.reply(`"${searchString}" didn't match any banned civs.`);
+        await civBotReply(interaction, `"${searchString}" didn't match any banned civs.`);
         return;
     }
     if (allMatchedCivs.length > 1) {
-        await interaction.reply(
+        await civBotReply(interaction, 
             `"${searchString}" matches ${allMatchedCivs.length} civs currently banned. Use the autocomplete to find the specific leader/civ you want to unban.`,
         );
         return;
     } else {
         const chosenCiv = allMatchedCivs[0];
         await unbanCivs(serverId, userData, [chosenCiv]);
-        await interaction.reply(unbanMessage(chosenCiv, userData.game));
+        await civBotReply(interaction, unbanMessage(chosenCiv, userData.game));
         return;
     }
 }

--- a/src/Commands/Config/ShowConfigCommand.ts
+++ b/src/Commands/Config/ShowConfigCommand.ts
@@ -4,11 +4,12 @@ import {CivId, getCiv, renderCiv} from "../../Civs/Civs";
 import {ChatInputCommandInteraction} from "discord.js";
 import {loadUserData} from "../../UserDataStore";
 import {CivGame} from "../../Civs/CivGames";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export async function showConfigCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
     let response = renderConfig(await loadUserData(serverId));
-    await interaction.reply(response);
+    await civBotReply(interaction, response);
 }
 
 function renderConfig(userData: UserData): string {

--- a/src/Commands/Draft/DraftCommand.ts
+++ b/src/Commands/Draft/DraftCommand.ts
@@ -7,6 +7,7 @@ import {ChatInputCommandInteraction} from "discord.js";
 import {getVoiceChannelMembers} from "../../Discord/VoiceChannels";
 import {loadUserData} from "../../UserDataStore";
 import {DraftedCiv} from "./DraftTypes";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export type DraftArguments = {
     numberOfAi: number;
@@ -42,7 +43,7 @@ export async function draftCommand(interaction: ChatInputCommandInteraction) {
         draftResult,
     );
 
-    await interaction.reply(draftMessage);
+    await civBotReply(interaction, draftMessage);
 }
 function fillDefaultArguments(partialArgs: Partial<DraftArguments>, userSettings: UserSettings): DraftArguments {
     const defaultArgs = userSettings.defaultDraftSettings;

--- a/src/Commands/Expansions/DisableExpansionCommand.ts
+++ b/src/Commands/Expansions/DisableExpansionCommand.ts
@@ -1,13 +1,14 @@
 import { Expansion, displayName, stringToExpansion } from "../../Civs/Expansions";
 import { loadUserData, saveUserData } from "../../UserDataStore";
 import { ChatInputCommandInteraction } from "discord.js";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export async function disableExpansionCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
     const expansion = stringToExpansion(interaction.options.getString("expansion")!)!;
 
     const message = await disableExpansion(serverId, expansion);
-    await interaction.reply(message);
+    await civBotReply(interaction, message);
 }
 
 async function disableExpansion(tenantId: string, expansion: Expansion): Promise<string> {

--- a/src/Commands/Expansions/EnableExpansion.ts
+++ b/src/Commands/Expansions/EnableExpansion.ts
@@ -1,13 +1,14 @@
 import { Expansion, displayName, stringToExpansion } from "../../Civs/Expansions";
 import { loadUserData, saveUserData } from "../../UserDataStore";
 import { ChatInputCommandInteraction } from "discord.js";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export async function enableExpansionCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
     const expansion = stringToExpansion(interaction.options.getString("expansion")!)!;
 
     const message = await enableExpansion(serverId, expansion);
-    await interaction.reply(message);
+    await civBotReply(interaction, message);
 }
 
 async function enableExpansion(tenantId: string, expansion: Expansion): Promise<string> {

--- a/src/Commands/SwitchGame/SwitchGameCommand.ts
+++ b/src/Commands/SwitchGame/SwitchGameCommand.ts
@@ -2,6 +2,7 @@ import { loadUserData, saveUserData } from "../../UserDataStore";
 import { CivGame } from "../../Civs/CivGames";
 import { ChatInputCommandInteraction } from "discord.js";
 import { updateSlashCommandsForServer } from "../../SlashCommands/UpdateSlashCommands";
+import {civBotReply} from "../../Discord/CivBotReply";
 
 export async function switchGameCommand(interaction: ChatInputCommandInteraction) {
     const serverId = interaction.guildId!;
@@ -10,7 +11,7 @@ export async function switchGameCommand(interaction: ChatInputCommandInteraction
 
     await updateSlashCommandsForServer(interaction.client, serverId);
 
-    await interaction.reply(`Switched to drafting for ${game}.`);
+    await civBotReply(interaction, `Switched to drafting for ${game}.`);
 }
 
 async function switchGame(tenantId: string) {

--- a/src/Discord/CivBotReply.ts
+++ b/src/Discord/CivBotReply.ts
@@ -1,0 +1,18 @@
+import {CommandInteraction, ModalSubmitInteraction} from "discord.js";
+import {loadUserData} from "../UserDataStore";
+import {isFeatureEnabled} from "../UserData/FeatureFlags";
+
+function addWowser(message: string) {
+    return `Wowser!\n${message}`;
+}
+
+export async function civBotReply(interaction: CommandInteraction | ModalSubmitInteraction, message: string) {
+    const userData = await loadUserData(interaction.guildId!);
+    
+    if (isFeatureEnabled(userData, "Wowser")) {
+        return await interaction.reply(addWowser(message));
+    }
+    else {
+        return await interaction.reply(message);
+    }
+}

--- a/src/Modals/HandleModalSubmit.ts
+++ b/src/Modals/HandleModalSubmit.ts
@@ -1,5 +1,6 @@
 import { ModalSubmitInteraction } from "discord.js";
 import { loadUserData, saveUserData } from "../UserDataStore";
+import {civBotReply} from "../Discord/CivBotReply";
 
 export async function handleModalSubmit(interaction: ModalSubmitInteraction) {
     if (interaction.customId === "customCivs") {
@@ -19,5 +20,5 @@ async function handleCustomCivsModal(interaction: ModalSubmitInteraction) {
 
     userData.userSettings[userData.game].customCivs = civs;
     await saveUserData(serverId, userData);
-    await interaction.reply(`Custom civs updated. You now have ${civs.length} custom civs.`);
+    await civBotReply(interaction, `Custom civs updated. You now have ${civs.length} custom civs.`);
 }

--- a/src/SlashCommands/HandleSlashCommand.ts
+++ b/src/SlashCommands/HandleSlashCommand.ts
@@ -8,6 +8,7 @@ import { disableExpansionCommand } from "../Commands/Expansions/DisableExpansion
 import { showConfigCommand } from "../Commands/Config/ShowConfigCommand";
 import { customCivsCommand } from "../Commands/CustomCivs/CustomCivsCommand";
 import { logError, logInfo } from "../Log";
+import {civBotReply} from "../Discord/CivBotReply";
 
 export async function handleSlashCommand(interaction: ChatInputCommandInteraction) {
     logInfo(
@@ -59,5 +60,5 @@ export async function handleSlashCommand(interaction: ChatInputCommandInteractio
     }
 
     logError(`Unrecognised slash command ${interaction.commandName}.`);
-    await interaction.reply("Sorry, I don't recognise that command. This is probably a bug.");
+    await civBotReply(interaction, "Sorry, I don't recognise that command. This is probably a bug.");
 }

--- a/src/Start.ts
+++ b/src/Start.ts
@@ -6,6 +6,7 @@ import { logException, logInfo } from "./Log";
 import { updateSlashCommandsForAllServers, updateSlashCommandsForServer } from "./SlashCommands/UpdateSlashCommands";
 import { handleModalSubmit } from "./Modals/HandleModalSubmit";
 import { banCommandAutocomplete, unbanCommandAutocomplete } from "./Commands/Ban/Autocomplete";
+import {civBotReply} from "./Discord/CivBotReply";
 
 async function start() {
     const client = new Client({
@@ -40,7 +41,7 @@ async function start() {
                 }
 
                 if (!interaction.replied) {
-                    await interaction.reply(Messages.GenericError);
+                    await civBotReply(interaction, Messages.GenericError);
                 }
             }
         }
@@ -52,7 +53,7 @@ async function start() {
                 if (e instanceof Error) {
                     logException(e);
                 }
-                await interaction.reply(Messages.GenericError);
+                await civBotReply(interaction, Messages.GenericError);
             }
         }
 

--- a/src/UserData/FeatureFlags.ts
+++ b/src/UserData/FeatureFlags.ts
@@ -1,6 +1,6 @@
 import { UserData } from "./UserData";
 
-export type FeatureFlag = "AllowReroll";
+export type FeatureFlag = "Wowser";
 
 export function isFeatureEnabled(userData: UserData, featureFlag: FeatureFlag) {
     return userData.featureFlags?.includes(featureFlag) ?? false;


### PR DESCRIPTION
Reintroduce wowser as an optional feature, behind a feature flag.

In doing so, scrapped the reroll feature. It's a pain to maintain and it's completely useless - you can just press up in the discord chat and it brings back the last command you ran.